### PR TITLE
feat: Add a new config to set the opacity of overlay

### DIFF
--- a/apps/desktop/src/components/user.tsx
+++ b/apps/desktop/src/components/user.tsx
@@ -3,13 +3,22 @@ import type { OverlayedUser } from "../types";
 import { HeadphonesOff } from "./icons/headphones-off";
 import { MicOff } from "./icons/mic-off";
 
-export const User = ({ item, alignDirection }: { item: OverlayedUser; alignDirection: DirectionLR }) => {
+export const User = ({
+  item,
+  alignDirection,
+  opacity,
+}: {
+  item: OverlayedUser;
+  alignDirection: DirectionLR;
+  opacity: number;
+}) => {
   const { id, selfMuted, selfDeafened, talking, muted, deafened, avatarHash } = item;
 
   const avatarUrl = avatarHash ? `https://cdn.discordapp.com/avatars/${id}/${avatarHash}.jpg` : "/img/default.png";
 
   const talkingClass = talking ? "border-green-500" : "border-zinc-800";
   const mutedClass = selfMuted || muted ? "text-zinc-400" : "";
+  const opacityStyle = talking ? "100%" : `${opacity}%`;
 
   // TODO: use tw merge so this looks better i guess
 
@@ -47,9 +56,10 @@ export const User = ({ item, alignDirection }: { item: OverlayedUser; alignDirec
 
   return (
     <div
-      className={`flex gap-2 py-1 p-2 justify-start items-center ${
+      className={`flex gap-2 py-1 p-2 justify-start items-center transition-opacity ${
         alignDirection == "right" ? "flex-row-reverse" : "flex-row"
       }`}
+      style={{ opacity: opacityStyle }}
     >
       <div className={`pointer-events-none relative rounded-full border-2 ${talkingClass}`}>
         <img

--- a/apps/desktop/src/config.ts
+++ b/apps/desktop/src/config.ts
@@ -16,6 +16,7 @@ export interface OverlayedConfig {
   joinHistoryNotifications: boolean;
   showOnlyTalkingUsers: boolean;
   showOwnUser: boolean;
+  opacity: number;
 }
 
 export type OverlayedConfigKey = keyof OverlayedConfig;
@@ -29,6 +30,7 @@ export const DEFAULT_OVERLAYED_CONFIG: OverlayedConfig = {
   joinHistoryNotifications: false,
   showOnlyTalkingUsers: false,
   showOwnUser: true,
+  opacity: 100,
 };
 
 const CONFIG_FILE_NAME = "config.json";

--- a/apps/desktop/src/views/channel.tsx
+++ b/apps/desktop/src/views/channel.tsx
@@ -8,6 +8,7 @@ export const ChannelView = ({ alignDirection }: { alignDirection: DirectionLR })
 
   const { value: showOnlyTalkingUsers } = useConfigValue("showOnlyTalkingUsers");
   const { value: showOwnUser } = useConfigValue("showOwnUser");
+  const { value: opacity } = useConfigValue("opacity");
 
   const allUsers = Object.entries(users);
   let userList = showOnlyTalkingUsers ? allUsers.filter(([, item]) => item.talking) : allUsers;
@@ -23,7 +24,7 @@ export const ChannelView = ({ alignDirection }: { alignDirection: DirectionLR })
     <div>
       <div className={`py-2 ${alignDirection === "center" ? "flex flex-wrap justify-center" : ""}`}>
         {userList.map(([, item]) => (
-          <User key={item.id} item={item} alignDirection={alignDirection} />
+          <User key={item.id} item={item} alignDirection={alignDirection} opacity={opacity} />
         ))}
       </div>
     </div>

--- a/apps/desktop/src/views/settings/account.tsx
+++ b/apps/desktop/src/views/settings/account.tsx
@@ -24,6 +24,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { VoiceUser } from "@/types";
 import { useConfigValue } from "@/hooks/use-config-value";
 import * as shell from "@tauri-apps/plugin-shell";
+import { Input } from "@/components/ui/input";
 
 export const Developer = () => {
   const platformInfo = usePlatformInfo();
@@ -69,6 +70,7 @@ const canaryVersionToCommit = (version: string) => {
 export const AppInfo = () => {
   const platformInfo = usePlatformInfo();
   const { value: showOnlyTalkingUsers } = useConfigValue("showOnlyTalkingUsers");
+  const { value: opacity } = useConfigValue("opacity");
 
   const urlForVersion = platformInfo.canary
     ? `https://github.com/overlayeddev/overlayed/commit/${canaryVersionToCommit(platformInfo.appVersion)}`
@@ -92,6 +94,28 @@ export const AppInfo = () => {
           className="ml-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
         >
           Only show users who are speaking
+        </label>
+      </div>
+      <div className="flex items-center pb-2">
+        <Input
+          id="opacity"
+          type="number"
+          min={1}
+          max={100}
+          value={opacity}
+          onChange={async event => {
+            const newOpacity = event.target.value;
+            await Config.set("opacity", Number(newOpacity));
+
+            await emit("config_update", await Config.getConfig());
+          }}
+          className="w-20"
+        />
+        <label
+          htmlFor="opacity"
+          className="ml-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
+          Overlay opacity
         </label>
       </div>
       <div className="flex items-center gap-2 pb-4 text-zinc-400">


### PR DESCRIPTION
fix #68

Hello,

First of all, thank you for your application! It’s a great addition to Discord 💫

I’ve added an opacity setting that allows users to adjust the widget’s transparency from 1 to 100. As mentioned in the issue, speaking users remain fully opaque.

For the input, I used the Input component to let users set the opacity, but let me know if you’d prefer a different one.

If you have any suggestions, feel free to let me know! 😊

## Screenshots

<img width="594" alt="Screenshot 2025-02-07 at 19 56 40" src="https://github.com/user-attachments/assets/8f6f65bf-66b5-4287-b646-4ce3143dff80" />

> Not speaking

<img width="591" alt="Screenshot 2025-02-07 at 19 56 47" src="https://github.com/user-attachments/assets/e58aea74-d714-4d2f-b14c-0fdc1c5a39aa" />

> Speaking