### PR TITLE
chore: Updated to latest `winget-releaser`

### DIFF
--- a/.github/workflows/winget-release.yaml
+++ b/.github/workflows/winget-release.yaml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal9/winget-releaser@a3ac67b0c3026bc335a33b722188e3ec769d6a64
+      - uses: vedantmgoyal9/winget-releaser@19e706d4c9121098010096f9c495a70a7518b30f
         with:
           identifier: OverlayedDev.Overlayed
           version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
This update is needed to fix some syncing issues with some recent GitHub API changes. This should allow the workflow to always work.