### PR TITLE
More options for positioning/anchor, opacity, name max length

### DIFF
--- a/LOCAL.md
+++ b/LOCAL.md
@@ -48,6 +48,11 @@ pnpm start:mocked
 pnpm build:desktop
 ```
 
+### 4b. Building locally without updater signing
+```
+pnpm build:desktop:unsigned
+```
+
 ### 5. Building the canary version locally
 ```
 pnpm build:canary

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,8 @@
 		"check:format": "prettier --check \"**/*.{ts,js,md}\"",
 		"clean": "rm -rf dist .turbo node_modules",
 		"format": "prettier --write .",
-		"start": "wrangler dev --remote --port 8787"
+		"start": "wrangler dev --local --port 8787",
+		"start:remote": "wrangler dev --remote --port 8787"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20250129.0",

--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -11,7 +11,8 @@
 		"clean": "rm -rf dist .turbo node_modules",
 		"register": "node --import tsx/esm ./src/register.ts",
 		"format": "prettier --write .",
-		"start": "wrangler dev --remote --port 8787"
+		"start": "wrangler dev --local --port 8788",
+		"start:remote": "wrangler dev --remote --port 8787"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20250129.0",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,6 +9,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "build:canary": "tauri build --config \"src-tauri/tauri.conf.canary.json\"",
+    "build:desktop:unsigned": "tauri build --config \"src-tauri/tauri.conf.unsigned.json\"",
     "generate:commit-hash": "node scripts/generate-commit-hash.js",
     "lint": "eslint",
     "clean": "rm -rf dist .turbo node_modules src-tauri/target",

--- a/apps/desktop/src-tauri/gen/schemas/windows-schema.json
+++ b/apps/desktop/src-tauri/gen/schemas/windows-schema.json
@@ -21,7 +21,9 @@
     {
       "description": "A list of capabilities.",
       "type": "object",
-      "required": ["capabilities"],
+      "required": [
+        "capabilities"
+      ],
       "properties": {
         "capabilities": {
           "description": "The list of capabilities.",
@@ -35,9 +37,12 @@
   ],
   "definitions": {
     "Capability": {
-      "description": "A grouping and boundary mechanism developers can use to isolate access to the IPC layer.\n\nIt controls application windows fine grained access to the Tauri core, application, or plugin commands. If a window is not matching any capability then it has no access to the IPC layer at all.\n\nThis can be done to create groups of windows, based on their required system access, which can reduce impact of frontend vulnerabilities in less privileged windows. Windows can be added to a capability by exact name (e.g. `main-window`) or glob patterns like `*` or `admin-*`. A Window can have none, one, or multiple associated capabilities.\n\n## Example\n\n```json { \"identifier\": \"main-user-files-write\", \"description\": \"This capability allows the `main` window on macOS and Windows access to `filesystem` write related commands and `dialog` commands to enable programatic access to files selected by the user.\", \"windows\": [ \"main\" ], \"permissions\": [ \"core:default\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] }, \"platforms\": [\"macOS\",\"windows\"] } ```",
+      "description": "A grouping and boundary mechanism developers can use to isolate access to the IPC layer.\n\nIt controls application windows fine grained access to the Tauri core, application, or plugin commands. If a window is not matching any capability then it has no access to the IPC layer at all.\n\nThis can be done to create groups of windows, based on their required system access, which can reduce impact of frontend vulnerabilities in less privileged windows. Windows can be added to a capability by exact name (e.g. `main-window`) or glob patterns like `*` or `admin-*`. A Window can have none, one, or multiple associated capabilities.\n\n## Example\n\n```json { \"identifier\": \"main-user-files-write\", \"description\": \"This capability allows the `main` window on macOS and Windows access to `filesystem` write related commands and `dialog` commands to enable programatic access to files selected by the user.\", \"windows\": [ \"main\" ], \"permissions\": [ \"core:default\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] }, ], \"platforms\": [\"macOS\",\"windows\"] } ```",
       "type": "object",
-      "required": ["identifier", "permissions"],
+      "required": [
+        "identifier",
+        "permissions"
+      ],
       "properties": {
         "identifier": {
           "description": "Identifier of the capability.\n\n## Example\n\n`main-user-files-write`",
@@ -79,7 +84,7 @@
           }
         },
         "permissions": {
-          "description": "List of permissions attached to this capability.\n\nMust include the plugin name as prefix in the form of `${plugin-name}:${permission-name}`. For commands directly implemented in the application itself only `${permission-name}` is required.\n\n## Example\n\n```json [ \"core:default\", \"shell:allow-open\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] } ```",
+          "description": "List of permissions attached to this capability.\n\nMust include the plugin name as prefix in the form of `${plugin-name}:${permission-name}`. For commands directly implemented in the application itself only `${permission-name}` is required.\n\n## Example\n\n```json [ \"core:default\", \"shell:allow-open\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] } ] ```",
           "type": "array",
           "items": {
             "$ref": "#/definitions/PermissionEntry"
@@ -88,7 +93,10 @@
         },
         "platforms": {
           "description": "Limit which target platforms this capability applies to.\n\nBy default all platforms are targeted.\n\n## Example\n\n`[\"macOS\",\"windows\"]`",
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/Target"
           }
@@ -98,7 +106,9 @@
     "CapabilityRemote": {
       "description": "Configuration for remote URLs that are associated with the capability.",
       "type": "object",
-      "required": ["urls"],
+      "required": [
+        "urls"
+      ],
       "properties": {
         "urls": {
           "description": "Remote domains this capability refers to using the [URLPattern standard](https://urlpattern.spec.whatwg.org/).\n\n## Examples\n\n- \"https://*.mydomain.dev\": allows subdomains of mydomain.dev - \"https://mydomain.dev/api/*\": allows any subpath of mydomain.dev/api",
@@ -123,4870 +133,5341 @@
         {
           "description": "Reference a permission or permission set by identifier and extends its scope.",
           "type": "object",
-          "oneOf": [
+          "allOf": [
             {
-              "type": "object",
-              "required": ["identifier"],
-              "properties": {
-                "identifier": {
-                  "oneOf": [
-                    {
-                      "description": "fs:default -> This set of permissions describes the what kind of\nfile system access the `fs` plugin has enabled or denied by default.\n\n#### Granted Permissions\n\nThis default permission set enables read access to the\napplication specific directories (AppConfig, AppData, AppLocalData, AppCache,\nAppLog) and all files and sub directories created in it.\nThe location of these directories depends on the operating system,\nwhere the application is run.\n\nIn general these directories need to be manually created\nby the application at runtime, before accessing files or folders\nin it is possible.\n\nTherefore, it is also allowed to create all of these folders via\nthe `mkdir` command.\n\n#### Denied Permissions\n\nThis default permission set prevents access to critical components\nof the Tauri application by default.\nOn Windows the webview data folder access is denied.\n\n",
-                      "type": "string",
-                      "enum": ["fs:default"]
-                    },
-                    {
-                      "description": "fs:allow-app-meta -> This allows non-recursive read access to metadata of the `$APP` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-app-meta"]
-                    },
-                    {
-                      "description": "fs:allow-app-meta-recursive -> This allows full recursive read access to metadata of the `$APP` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-app-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-app-read -> This allows non-recursive read access to the `$APP` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-app-read"]
-                    },
-                    {
-                      "description": "fs:allow-app-read-recursive -> This allows full recursive read access to the complete `$APP` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-app-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-app-write -> This allows non-recursive write access to the `$APP` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-app-write"]
-                    },
-                    {
-                      "description": "fs:allow-app-write-recursive -> This allows full recursive write access to the complete `$APP` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-app-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-appcache-meta -> This allows non-recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-appcache-meta"]
-                    },
-                    {
-                      "description": "fs:allow-appcache-meta-recursive -> This allows full recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-appcache-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-appcache-read -> This allows non-recursive read access to the `$APPCACHE` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-appcache-read"]
-                    },
-                    {
-                      "description": "fs:allow-appcache-read-recursive -> This allows full recursive read access to the complete `$APPCACHE` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-appcache-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-appcache-write -> This allows non-recursive write access to the `$APPCACHE` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-appcache-write"]
-                    },
-                    {
-                      "description": "fs:allow-appcache-write-recursive -> This allows full recursive write access to the complete `$APPCACHE` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-appcache-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-appconfig-meta -> This allows non-recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-appconfig-meta"]
-                    },
-                    {
-                      "description": "fs:allow-appconfig-meta-recursive -> This allows full recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-appconfig-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-appconfig-read -> This allows non-recursive read access to the `$APPCONFIG` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-appconfig-read"]
-                    },
-                    {
-                      "description": "fs:allow-appconfig-read-recursive -> This allows full recursive read access to the complete `$APPCONFIG` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-appconfig-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-appconfig-write -> This allows non-recursive write access to the `$APPCONFIG` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-appconfig-write"]
-                    },
-                    {
-                      "description": "fs:allow-appconfig-write-recursive -> This allows full recursive write access to the complete `$APPCONFIG` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-appconfig-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-appdata-meta -> This allows non-recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-appdata-meta"]
-                    },
-                    {
-                      "description": "fs:allow-appdata-meta-recursive -> This allows full recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-appdata-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-appdata-read -> This allows non-recursive read access to the `$APPDATA` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-appdata-read"]
-                    },
-                    {
-                      "description": "fs:allow-appdata-read-recursive -> This allows full recursive read access to the complete `$APPDATA` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-appdata-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-appdata-write -> This allows non-recursive write access to the `$APPDATA` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-appdata-write"]
-                    },
-                    {
-                      "description": "fs:allow-appdata-write-recursive -> This allows full recursive write access to the complete `$APPDATA` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-appdata-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-applocaldata-meta -> This allows non-recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-applocaldata-meta"]
-                    },
-                    {
-                      "description": "fs:allow-applocaldata-meta-recursive -> This allows full recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-applocaldata-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-applocaldata-read -> This allows non-recursive read access to the `$APPLOCALDATA` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-applocaldata-read"]
-                    },
-                    {
-                      "description": "fs:allow-applocaldata-read-recursive -> This allows full recursive read access to the complete `$APPLOCALDATA` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-applocaldata-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-applocaldata-write -> This allows non-recursive write access to the `$APPLOCALDATA` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-applocaldata-write"]
-                    },
-                    {
-                      "description": "fs:allow-applocaldata-write-recursive -> This allows full recursive write access to the complete `$APPLOCALDATA` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-applocaldata-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-applog-meta -> This allows non-recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-applog-meta"]
-                    },
-                    {
-                      "description": "fs:allow-applog-meta-recursive -> This allows full recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-applog-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-applog-read -> This allows non-recursive read access to the `$APPLOG` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-applog-read"]
-                    },
-                    {
-                      "description": "fs:allow-applog-read-recursive -> This allows full recursive read access to the complete `$APPLOG` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-applog-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-applog-write -> This allows non-recursive write access to the `$APPLOG` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-applog-write"]
-                    },
-                    {
-                      "description": "fs:allow-applog-write-recursive -> This allows full recursive write access to the complete `$APPLOG` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-applog-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-audio-meta -> This allows non-recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-audio-meta"]
-                    },
-                    {
-                      "description": "fs:allow-audio-meta-recursive -> This allows full recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-audio-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-audio-read -> This allows non-recursive read access to the `$AUDIO` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-audio-read"]
-                    },
-                    {
-                      "description": "fs:allow-audio-read-recursive -> This allows full recursive read access to the complete `$AUDIO` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-audio-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-audio-write -> This allows non-recursive write access to the `$AUDIO` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-audio-write"]
-                    },
-                    {
-                      "description": "fs:allow-audio-write-recursive -> This allows full recursive write access to the complete `$AUDIO` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-audio-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-cache-meta -> This allows non-recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-cache-meta"]
-                    },
-                    {
-                      "description": "fs:allow-cache-meta-recursive -> This allows full recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-cache-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-cache-read -> This allows non-recursive read access to the `$CACHE` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-cache-read"]
-                    },
-                    {
-                      "description": "fs:allow-cache-read-recursive -> This allows full recursive read access to the complete `$CACHE` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-cache-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-cache-write -> This allows non-recursive write access to the `$CACHE` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-cache-write"]
-                    },
-                    {
-                      "description": "fs:allow-cache-write-recursive -> This allows full recursive write access to the complete `$CACHE` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-cache-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-config-meta -> This allows non-recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-config-meta"]
-                    },
-                    {
-                      "description": "fs:allow-config-meta-recursive -> This allows full recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-config-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-config-read -> This allows non-recursive read access to the `$CONFIG` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-config-read"]
-                    },
-                    {
-                      "description": "fs:allow-config-read-recursive -> This allows full recursive read access to the complete `$CONFIG` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-config-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-config-write -> This allows non-recursive write access to the `$CONFIG` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-config-write"]
-                    },
-                    {
-                      "description": "fs:allow-config-write-recursive -> This allows full recursive write access to the complete `$CONFIG` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-config-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-data-meta -> This allows non-recursive read access to metadata of the `$DATA` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-data-meta"]
-                    },
-                    {
-                      "description": "fs:allow-data-meta-recursive -> This allows full recursive read access to metadata of the `$DATA` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-data-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-data-read -> This allows non-recursive read access to the `$DATA` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-data-read"]
-                    },
-                    {
-                      "description": "fs:allow-data-read-recursive -> This allows full recursive read access to the complete `$DATA` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-data-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-data-write -> This allows non-recursive write access to the `$DATA` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-data-write"]
-                    },
-                    {
-                      "description": "fs:allow-data-write-recursive -> This allows full recursive write access to the complete `$DATA` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-data-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-desktop-meta -> This allows non-recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-desktop-meta"]
-                    },
-                    {
-                      "description": "fs:allow-desktop-meta-recursive -> This allows full recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-desktop-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-desktop-read -> This allows non-recursive read access to the `$DESKTOP` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-desktop-read"]
-                    },
-                    {
-                      "description": "fs:allow-desktop-read-recursive -> This allows full recursive read access to the complete `$DESKTOP` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-desktop-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-desktop-write -> This allows non-recursive write access to the `$DESKTOP` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-desktop-write"]
-                    },
-                    {
-                      "description": "fs:allow-desktop-write-recursive -> This allows full recursive write access to the complete `$DESKTOP` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-desktop-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-document-meta -> This allows non-recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-document-meta"]
-                    },
-                    {
-                      "description": "fs:allow-document-meta-recursive -> This allows full recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-document-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-document-read -> This allows non-recursive read access to the `$DOCUMENT` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-document-read"]
-                    },
-                    {
-                      "description": "fs:allow-document-read-recursive -> This allows full recursive read access to the complete `$DOCUMENT` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-document-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-document-write -> This allows non-recursive write access to the `$DOCUMENT` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-document-write"]
-                    },
-                    {
-                      "description": "fs:allow-document-write-recursive -> This allows full recursive write access to the complete `$DOCUMENT` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-document-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-download-meta -> This allows non-recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-download-meta"]
-                    },
-                    {
-                      "description": "fs:allow-download-meta-recursive -> This allows full recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-download-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-download-read -> This allows non-recursive read access to the `$DOWNLOAD` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-download-read"]
-                    },
-                    {
-                      "description": "fs:allow-download-read-recursive -> This allows full recursive read access to the complete `$DOWNLOAD` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-download-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-download-write -> This allows non-recursive write access to the `$DOWNLOAD` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-download-write"]
-                    },
-                    {
-                      "description": "fs:allow-download-write-recursive -> This allows full recursive write access to the complete `$DOWNLOAD` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-download-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-exe-meta -> This allows non-recursive read access to metadata of the `$EXE` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-exe-meta"]
-                    },
-                    {
-                      "description": "fs:allow-exe-meta-recursive -> This allows full recursive read access to metadata of the `$EXE` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-exe-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-exe-read -> This allows non-recursive read access to the `$EXE` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-exe-read"]
-                    },
-                    {
-                      "description": "fs:allow-exe-read-recursive -> This allows full recursive read access to the complete `$EXE` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-exe-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-exe-write -> This allows non-recursive write access to the `$EXE` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-exe-write"]
-                    },
-                    {
-                      "description": "fs:allow-exe-write-recursive -> This allows full recursive write access to the complete `$EXE` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-exe-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-font-meta -> This allows non-recursive read access to metadata of the `$FONT` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-font-meta"]
-                    },
-                    {
-                      "description": "fs:allow-font-meta-recursive -> This allows full recursive read access to metadata of the `$FONT` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-font-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-font-read -> This allows non-recursive read access to the `$FONT` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-font-read"]
-                    },
-                    {
-                      "description": "fs:allow-font-read-recursive -> This allows full recursive read access to the complete `$FONT` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-font-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-font-write -> This allows non-recursive write access to the `$FONT` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-font-write"]
-                    },
-                    {
-                      "description": "fs:allow-font-write-recursive -> This allows full recursive write access to the complete `$FONT` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-font-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-home-meta -> This allows non-recursive read access to metadata of the `$HOME` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-home-meta"]
-                    },
-                    {
-                      "description": "fs:allow-home-meta-recursive -> This allows full recursive read access to metadata of the `$HOME` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-home-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-home-read -> This allows non-recursive read access to the `$HOME` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-home-read"]
-                    },
-                    {
-                      "description": "fs:allow-home-read-recursive -> This allows full recursive read access to the complete `$HOME` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-home-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-home-write -> This allows non-recursive write access to the `$HOME` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-home-write"]
-                    },
-                    {
-                      "description": "fs:allow-home-write-recursive -> This allows full recursive write access to the complete `$HOME` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-home-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-localdata-meta -> This allows non-recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-localdata-meta"]
-                    },
-                    {
-                      "description": "fs:allow-localdata-meta-recursive -> This allows full recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-localdata-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-localdata-read -> This allows non-recursive read access to the `$LOCALDATA` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-localdata-read"]
-                    },
-                    {
-                      "description": "fs:allow-localdata-read-recursive -> This allows full recursive read access to the complete `$LOCALDATA` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-localdata-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-localdata-write -> This allows non-recursive write access to the `$LOCALDATA` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-localdata-write"]
-                    },
-                    {
-                      "description": "fs:allow-localdata-write-recursive -> This allows full recursive write access to the complete `$LOCALDATA` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-localdata-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-log-meta -> This allows non-recursive read access to metadata of the `$LOG` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-log-meta"]
-                    },
-                    {
-                      "description": "fs:allow-log-meta-recursive -> This allows full recursive read access to metadata of the `$LOG` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-log-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-log-read -> This allows non-recursive read access to the `$LOG` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-log-read"]
-                    },
-                    {
-                      "description": "fs:allow-log-read-recursive -> This allows full recursive read access to the complete `$LOG` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-log-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-log-write -> This allows non-recursive write access to the `$LOG` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-log-write"]
-                    },
-                    {
-                      "description": "fs:allow-log-write-recursive -> This allows full recursive write access to the complete `$LOG` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-log-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-picture-meta -> This allows non-recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-picture-meta"]
-                    },
-                    {
-                      "description": "fs:allow-picture-meta-recursive -> This allows full recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-picture-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-picture-read -> This allows non-recursive read access to the `$PICTURE` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-picture-read"]
-                    },
-                    {
-                      "description": "fs:allow-picture-read-recursive -> This allows full recursive read access to the complete `$PICTURE` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-picture-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-picture-write -> This allows non-recursive write access to the `$PICTURE` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-picture-write"]
-                    },
-                    {
-                      "description": "fs:allow-picture-write-recursive -> This allows full recursive write access to the complete `$PICTURE` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-picture-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-public-meta -> This allows non-recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-public-meta"]
-                    },
-                    {
-                      "description": "fs:allow-public-meta-recursive -> This allows full recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-public-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-public-read -> This allows non-recursive read access to the `$PUBLIC` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-public-read"]
-                    },
-                    {
-                      "description": "fs:allow-public-read-recursive -> This allows full recursive read access to the complete `$PUBLIC` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-public-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-public-write -> This allows non-recursive write access to the `$PUBLIC` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-public-write"]
-                    },
-                    {
-                      "description": "fs:allow-public-write-recursive -> This allows full recursive write access to the complete `$PUBLIC` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-public-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-resource-meta -> This allows non-recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-resource-meta"]
-                    },
-                    {
-                      "description": "fs:allow-resource-meta-recursive -> This allows full recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-resource-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-resource-read -> This allows non-recursive read access to the `$RESOURCE` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-resource-read"]
-                    },
-                    {
-                      "description": "fs:allow-resource-read-recursive -> This allows full recursive read access to the complete `$RESOURCE` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-resource-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-resource-write -> This allows non-recursive write access to the `$RESOURCE` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-resource-write"]
-                    },
-                    {
-                      "description": "fs:allow-resource-write-recursive -> This allows full recursive write access to the complete `$RESOURCE` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-resource-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-runtime-meta -> This allows non-recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-runtime-meta"]
-                    },
-                    {
-                      "description": "fs:allow-runtime-meta-recursive -> This allows full recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-runtime-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-runtime-read -> This allows non-recursive read access to the `$RUNTIME` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-runtime-read"]
-                    },
-                    {
-                      "description": "fs:allow-runtime-read-recursive -> This allows full recursive read access to the complete `$RUNTIME` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-runtime-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-runtime-write -> This allows non-recursive write access to the `$RUNTIME` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-runtime-write"]
-                    },
-                    {
-                      "description": "fs:allow-runtime-write-recursive -> This allows full recursive write access to the complete `$RUNTIME` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-runtime-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-temp-meta -> This allows non-recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-temp-meta"]
-                    },
-                    {
-                      "description": "fs:allow-temp-meta-recursive -> This allows full recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-temp-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-temp-read -> This allows non-recursive read access to the `$TEMP` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-temp-read"]
-                    },
-                    {
-                      "description": "fs:allow-temp-read-recursive -> This allows full recursive read access to the complete `$TEMP` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-temp-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-temp-write -> This allows non-recursive write access to the `$TEMP` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-temp-write"]
-                    },
-                    {
-                      "description": "fs:allow-temp-write-recursive -> This allows full recursive write access to the complete `$TEMP` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-temp-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-template-meta -> This allows non-recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-template-meta"]
-                    },
-                    {
-                      "description": "fs:allow-template-meta-recursive -> This allows full recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-template-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-template-read -> This allows non-recursive read access to the `$TEMPLATE` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-template-read"]
-                    },
-                    {
-                      "description": "fs:allow-template-read-recursive -> This allows full recursive read access to the complete `$TEMPLATE` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-template-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-template-write -> This allows non-recursive write access to the `$TEMPLATE` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-template-write"]
-                    },
-                    {
-                      "description": "fs:allow-template-write-recursive -> This allows full recursive write access to the complete `$TEMPLATE` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-template-write-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-video-meta -> This allows non-recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-video-meta"]
-                    },
-                    {
-                      "description": "fs:allow-video-meta-recursive -> This allows full recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.",
-                      "type": "string",
-                      "enum": ["fs:allow-video-meta-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-video-read -> This allows non-recursive read access to the `$VIDEO` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-video-read"]
-                    },
-                    {
-                      "description": "fs:allow-video-read-recursive -> This allows full recursive read access to the complete `$VIDEO` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-video-read-recursive"]
-                    },
-                    {
-                      "description": "fs:allow-video-write -> This allows non-recursive write access to the `$VIDEO` folder.",
-                      "type": "string",
-                      "enum": ["fs:allow-video-write"]
-                    },
-                    {
-                      "description": "fs:allow-video-write-recursive -> This allows full recursive write access to the complete `$VIDEO` folder, files and subdirectories.",
-                      "type": "string",
-                      "enum": ["fs:allow-video-write-recursive"]
-                    },
-                    {
-                      "description": "fs:deny-default -> This denies access to dangerous Tauri relevant files and folders by default.",
-                      "type": "string",
-                      "enum": ["fs:deny-default"]
-                    },
-                    {
-                      "description": "fs:allow-copy-file -> Enables the copy_file command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-copy-file"]
-                    },
-                    {
-                      "description": "fs:allow-create -> Enables the create command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-create"]
-                    },
-                    {
-                      "description": "fs:allow-exists -> Enables the exists command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-exists"]
-                    },
-                    {
-                      "description": "fs:allow-fstat -> Enables the fstat command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-fstat"]
-                    },
-                    {
-                      "description": "fs:allow-ftruncate -> Enables the ftruncate command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-ftruncate"]
-                    },
-                    {
-                      "description": "fs:allow-lstat -> Enables the lstat command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-lstat"]
-                    },
-                    {
-                      "description": "fs:allow-mkdir -> Enables the mkdir command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-mkdir"]
-                    },
-                    {
-                      "description": "fs:allow-open -> Enables the open command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-open"]
-                    },
-                    {
-                      "description": "fs:allow-read -> Enables the read command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-read"]
-                    },
-                    {
-                      "description": "fs:allow-read-dir -> Enables the read_dir command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-read-dir"]
-                    },
-                    {
-                      "description": "fs:allow-read-file -> Enables the read_file command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-read-file"]
-                    },
-                    {
-                      "description": "fs:allow-read-text-file -> Enables the read_text_file command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-read-text-file"]
-                    },
-                    {
-                      "description": "fs:allow-read-text-file-lines -> Enables the read_text_file_lines command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-read-text-file-lines"]
-                    },
-                    {
-                      "description": "fs:allow-read-text-file-lines-next -> Enables the read_text_file_lines_next command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-read-text-file-lines-next"]
-                    },
-                    {
-                      "description": "fs:allow-remove -> Enables the remove command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-remove"]
-                    },
-                    {
-                      "description": "fs:allow-rename -> Enables the rename command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-rename"]
-                    },
-                    {
-                      "description": "fs:allow-seek -> Enables the seek command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-seek"]
-                    },
-                    {
-                      "description": "fs:allow-stat -> Enables the stat command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-stat"]
-                    },
-                    {
-                      "description": "fs:allow-truncate -> Enables the truncate command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-truncate"]
-                    },
-                    {
-                      "description": "fs:allow-unwatch -> Enables the unwatch command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-unwatch"]
-                    },
-                    {
-                      "description": "fs:allow-watch -> Enables the watch command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-watch"]
-                    },
-                    {
-                      "description": "fs:allow-write -> Enables the write command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-write"]
-                    },
-                    {
-                      "description": "fs:allow-write-file -> Enables the write_file command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-write-file"]
-                    },
-                    {
-                      "description": "fs:allow-write-text-file -> Enables the write_text_file command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:allow-write-text-file"]
-                    },
-                    {
-                      "description": "fs:create-app-specific-dirs -> This permissions allows to create the application specific directories.\n",
-                      "type": "string",
-                      "enum": ["fs:create-app-specific-dirs"]
-                    },
-                    {
-                      "description": "fs:deny-copy-file -> Denies the copy_file command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-copy-file"]
-                    },
-                    {
-                      "description": "fs:deny-create -> Denies the create command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-create"]
-                    },
-                    {
-                      "description": "fs:deny-exists -> Denies the exists command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-exists"]
-                    },
-                    {
-                      "description": "fs:deny-fstat -> Denies the fstat command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-fstat"]
-                    },
-                    {
-                      "description": "fs:deny-ftruncate -> Denies the ftruncate command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-ftruncate"]
-                    },
-                    {
-                      "description": "fs:deny-lstat -> Denies the lstat command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-lstat"]
-                    },
-                    {
-                      "description": "fs:deny-mkdir -> Denies the mkdir command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-mkdir"]
-                    },
-                    {
-                      "description": "fs:deny-open -> Denies the open command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-open"]
-                    },
-                    {
-                      "description": "fs:deny-read -> Denies the read command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-read"]
-                    },
-                    {
-                      "description": "fs:deny-read-dir -> Denies the read_dir command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-read-dir"]
-                    },
-                    {
-                      "description": "fs:deny-read-file -> Denies the read_file command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-read-file"]
-                    },
-                    {
-                      "description": "fs:deny-read-text-file -> Denies the read_text_file command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-read-text-file"]
-                    },
-                    {
-                      "description": "fs:deny-read-text-file-lines -> Denies the read_text_file_lines command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-read-text-file-lines"]
-                    },
-                    {
-                      "description": "fs:deny-read-text-file-lines-next -> Denies the read_text_file_lines_next command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-read-text-file-lines-next"]
-                    },
-                    {
-                      "description": "fs:deny-remove -> Denies the remove command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-remove"]
-                    },
-                    {
-                      "description": "fs:deny-rename -> Denies the rename command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-rename"]
-                    },
-                    {
-                      "description": "fs:deny-seek -> Denies the seek command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-seek"]
-                    },
-                    {
-                      "description": "fs:deny-stat -> Denies the stat command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-stat"]
-                    },
-                    {
-                      "description": "fs:deny-truncate -> Denies the truncate command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-truncate"]
-                    },
-                    {
-                      "description": "fs:deny-unwatch -> Denies the unwatch command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-unwatch"]
-                    },
-                    {
-                      "description": "fs:deny-watch -> Denies the watch command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-watch"]
-                    },
-                    {
-                      "description": "fs:deny-webview-data-linux -> This denies read access to the\n`$APPLOCALDATA` folder on linux as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
-                      "type": "string",
-                      "enum": ["fs:deny-webview-data-linux"]
-                    },
-                    {
-                      "description": "fs:deny-webview-data-windows -> This denies read access to the\n`$APPLOCALDATA/EBWebView` folder on windows as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
-                      "type": "string",
-                      "enum": ["fs:deny-webview-data-windows"]
-                    },
-                    {
-                      "description": "fs:deny-write -> Denies the write command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-write"]
-                    },
-                    {
-                      "description": "fs:deny-write-file -> Denies the write_file command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-write-file"]
-                    },
-                    {
-                      "description": "fs:deny-write-text-file -> Denies the write_text_file command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["fs:deny-write-text-file"]
-                    },
-                    {
-                      "description": "fs:read-all -> This enables all read related commands without any pre-configured accessible paths.",
-                      "type": "string",
-                      "enum": ["fs:read-all"]
-                    },
-                    {
-                      "description": "fs:read-app-specific-dirs-recursive -> This permission allows recursive read functionality on the application\nspecific base directories. \n",
-                      "type": "string",
-                      "enum": ["fs:read-app-specific-dirs-recursive"]
-                    },
-                    {
-                      "description": "fs:read-dirs -> This enables directory read and file metadata related commands without any pre-configured accessible paths.",
-                      "type": "string",
-                      "enum": ["fs:read-dirs"]
-                    },
-                    {
-                      "description": "fs:read-files -> This enables file read related commands without any pre-configured accessible paths.",
-                      "type": "string",
-                      "enum": ["fs:read-files"]
-                    },
-                    {
-                      "description": "fs:read-meta -> This enables all index or metadata related commands without any pre-configured accessible paths.",
-                      "type": "string",
-                      "enum": ["fs:read-meta"]
-                    },
-                    {
-                      "description": "fs:scope -> An empty permission you can use to modify the global scope.",
-                      "type": "string",
-                      "enum": ["fs:scope"]
-                    },
-                    {
-                      "description": "fs:scope-app -> This scope permits access to all files and list content of top level directories in the `$APP`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-app"]
-                    },
-                    {
-                      "description": "fs:scope-app-index -> This scope permits to list all files and folders in the `$APP`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-app-index"]
-                    },
-                    {
-                      "description": "fs:scope-app-recursive -> This scope permits recursive access to the complete `$APP` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-app-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-appcache -> This scope permits access to all files and list content of top level directories in the `$APPCACHE`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-appcache"]
-                    },
-                    {
-                      "description": "fs:scope-appcache-index -> This scope permits to list all files and folders in the `$APPCACHE`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-appcache-index"]
-                    },
-                    {
-                      "description": "fs:scope-appcache-recursive -> This scope permits recursive access to the complete `$APPCACHE` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-appcache-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-appconfig -> This scope permits access to all files and list content of top level directories in the `$APPCONFIG`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-appconfig"]
-                    },
-                    {
-                      "description": "fs:scope-appconfig-index -> This scope permits to list all files and folders in the `$APPCONFIG`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-appconfig-index"]
-                    },
-                    {
-                      "description": "fs:scope-appconfig-recursive -> This scope permits recursive access to the complete `$APPCONFIG` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-appconfig-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-appdata -> This scope permits access to all files and list content of top level directories in the `$APPDATA`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-appdata"]
-                    },
-                    {
-                      "description": "fs:scope-appdata-index -> This scope permits to list all files and folders in the `$APPDATA`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-appdata-index"]
-                    },
-                    {
-                      "description": "fs:scope-appdata-recursive -> This scope permits recursive access to the complete `$APPDATA` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-appdata-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-applocaldata -> This scope permits access to all files and list content of top level directories in the `$APPLOCALDATA`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-applocaldata"]
-                    },
-                    {
-                      "description": "fs:scope-applocaldata-index -> This scope permits to list all files and folders in the `$APPLOCALDATA`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-applocaldata-index"]
-                    },
-                    {
-                      "description": "fs:scope-applocaldata-recursive -> This scope permits recursive access to the complete `$APPLOCALDATA` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-applocaldata-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-applog -> This scope permits access to all files and list content of top level directories in the `$APPLOG`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-applog"]
-                    },
-                    {
-                      "description": "fs:scope-applog-index -> This scope permits to list all files and folders in the `$APPLOG`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-applog-index"]
-                    },
-                    {
-                      "description": "fs:scope-applog-recursive -> This scope permits recursive access to the complete `$APPLOG` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-applog-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-audio -> This scope permits access to all files and list content of top level directories in the `$AUDIO`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-audio"]
-                    },
-                    {
-                      "description": "fs:scope-audio-index -> This scope permits to list all files and folders in the `$AUDIO`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-audio-index"]
-                    },
-                    {
-                      "description": "fs:scope-audio-recursive -> This scope permits recursive access to the complete `$AUDIO` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-audio-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-cache -> This scope permits access to all files and list content of top level directories in the `$CACHE`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-cache"]
-                    },
-                    {
-                      "description": "fs:scope-cache-index -> This scope permits to list all files and folders in the `$CACHE`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-cache-index"]
-                    },
-                    {
-                      "description": "fs:scope-cache-recursive -> This scope permits recursive access to the complete `$CACHE` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-cache-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-config -> This scope permits access to all files and list content of top level directories in the `$CONFIG`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-config"]
-                    },
-                    {
-                      "description": "fs:scope-config-index -> This scope permits to list all files and folders in the `$CONFIG`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-config-index"]
-                    },
-                    {
-                      "description": "fs:scope-config-recursive -> This scope permits recursive access to the complete `$CONFIG` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-config-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-data -> This scope permits access to all files and list content of top level directories in the `$DATA`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-data"]
-                    },
-                    {
-                      "description": "fs:scope-data-index -> This scope permits to list all files and folders in the `$DATA`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-data-index"]
-                    },
-                    {
-                      "description": "fs:scope-data-recursive -> This scope permits recursive access to the complete `$DATA` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-data-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-desktop -> This scope permits access to all files and list content of top level directories in the `$DESKTOP`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-desktop"]
-                    },
-                    {
-                      "description": "fs:scope-desktop-index -> This scope permits to list all files and folders in the `$DESKTOP`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-desktop-index"]
-                    },
-                    {
-                      "description": "fs:scope-desktop-recursive -> This scope permits recursive access to the complete `$DESKTOP` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-desktop-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-document -> This scope permits access to all files and list content of top level directories in the `$DOCUMENT`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-document"]
-                    },
-                    {
-                      "description": "fs:scope-document-index -> This scope permits to list all files and folders in the `$DOCUMENT`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-document-index"]
-                    },
-                    {
-                      "description": "fs:scope-document-recursive -> This scope permits recursive access to the complete `$DOCUMENT` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-document-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-download -> This scope permits access to all files and list content of top level directories in the `$DOWNLOAD`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-download"]
-                    },
-                    {
-                      "description": "fs:scope-download-index -> This scope permits to list all files and folders in the `$DOWNLOAD`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-download-index"]
-                    },
-                    {
-                      "description": "fs:scope-download-recursive -> This scope permits recursive access to the complete `$DOWNLOAD` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-download-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-exe -> This scope permits access to all files and list content of top level directories in the `$EXE`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-exe"]
-                    },
-                    {
-                      "description": "fs:scope-exe-index -> This scope permits to list all files and folders in the `$EXE`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-exe-index"]
-                    },
-                    {
-                      "description": "fs:scope-exe-recursive -> This scope permits recursive access to the complete `$EXE` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-exe-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-font -> This scope permits access to all files and list content of top level directories in the `$FONT`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-font"]
-                    },
-                    {
-                      "description": "fs:scope-font-index -> This scope permits to list all files and folders in the `$FONT`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-font-index"]
-                    },
-                    {
-                      "description": "fs:scope-font-recursive -> This scope permits recursive access to the complete `$FONT` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-font-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-home -> This scope permits access to all files and list content of top level directories in the `$HOME`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-home"]
-                    },
-                    {
-                      "description": "fs:scope-home-index -> This scope permits to list all files and folders in the `$HOME`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-home-index"]
-                    },
-                    {
-                      "description": "fs:scope-home-recursive -> This scope permits recursive access to the complete `$HOME` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-home-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-localdata -> This scope permits access to all files and list content of top level directories in the `$LOCALDATA`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-localdata"]
-                    },
-                    {
-                      "description": "fs:scope-localdata-index -> This scope permits to list all files and folders in the `$LOCALDATA`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-localdata-index"]
-                    },
-                    {
-                      "description": "fs:scope-localdata-recursive -> This scope permits recursive access to the complete `$LOCALDATA` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-localdata-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-log -> This scope permits access to all files and list content of top level directories in the `$LOG`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-log"]
-                    },
-                    {
-                      "description": "fs:scope-log-index -> This scope permits to list all files and folders in the `$LOG`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-log-index"]
-                    },
-                    {
-                      "description": "fs:scope-log-recursive -> This scope permits recursive access to the complete `$LOG` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-log-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-picture -> This scope permits access to all files and list content of top level directories in the `$PICTURE`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-picture"]
-                    },
-                    {
-                      "description": "fs:scope-picture-index -> This scope permits to list all files and folders in the `$PICTURE`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-picture-index"]
-                    },
-                    {
-                      "description": "fs:scope-picture-recursive -> This scope permits recursive access to the complete `$PICTURE` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-picture-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-public -> This scope permits access to all files and list content of top level directories in the `$PUBLIC`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-public"]
-                    },
-                    {
-                      "description": "fs:scope-public-index -> This scope permits to list all files and folders in the `$PUBLIC`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-public-index"]
-                    },
-                    {
-                      "description": "fs:scope-public-recursive -> This scope permits recursive access to the complete `$PUBLIC` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-public-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-resource -> This scope permits access to all files and list content of top level directories in the `$RESOURCE`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-resource"]
-                    },
-                    {
-                      "description": "fs:scope-resource-index -> This scope permits to list all files and folders in the `$RESOURCE`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-resource-index"]
-                    },
-                    {
-                      "description": "fs:scope-resource-recursive -> This scope permits recursive access to the complete `$RESOURCE` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-resource-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-runtime -> This scope permits access to all files and list content of top level directories in the `$RUNTIME`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-runtime"]
-                    },
-                    {
-                      "description": "fs:scope-runtime-index -> This scope permits to list all files and folders in the `$RUNTIME`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-runtime-index"]
-                    },
-                    {
-                      "description": "fs:scope-runtime-recursive -> This scope permits recursive access to the complete `$RUNTIME` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-runtime-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-temp -> This scope permits access to all files and list content of top level directories in the `$TEMP`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-temp"]
-                    },
-                    {
-                      "description": "fs:scope-temp-index -> This scope permits to list all files and folders in the `$TEMP`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-temp-index"]
-                    },
-                    {
-                      "description": "fs:scope-temp-recursive -> This scope permits recursive access to the complete `$TEMP` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-temp-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-template -> This scope permits access to all files and list content of top level directories in the `$TEMPLATE`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-template"]
-                    },
-                    {
-                      "description": "fs:scope-template-index -> This scope permits to list all files and folders in the `$TEMPLATE`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-template-index"]
-                    },
-                    {
-                      "description": "fs:scope-template-recursive -> This scope permits recursive access to the complete `$TEMPLATE` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-template-recursive"]
-                    },
-                    {
-                      "description": "fs:scope-video -> This scope permits access to all files and list content of top level directories in the `$VIDEO`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-video"]
-                    },
-                    {
-                      "description": "fs:scope-video-index -> This scope permits to list all files and folders in the `$VIDEO`folder.",
-                      "type": "string",
-                      "enum": ["fs:scope-video-index"]
-                    },
-                    {
-                      "description": "fs:scope-video-recursive -> This scope permits recursive access to the complete `$VIDEO` folder, including sub directories and files.",
-                      "type": "string",
-                      "enum": ["fs:scope-video-recursive"]
-                    },
-                    {
-                      "description": "fs:write-all -> This enables all write related commands without any pre-configured accessible paths.",
-                      "type": "string",
-                      "enum": ["fs:write-all"]
-                    },
-                    {
-                      "description": "fs:write-files -> This enables all file write related commands without any pre-configured accessible paths.",
-                      "type": "string",
-                      "enum": ["fs:write-files"]
-                    }
-                  ]
-                },
-                "allow": {
-                  "items": {
-                    "title": "FsScopeEntry",
-                    "description": "FS scope entry.",
+              "if": {
+                "properties": {
+                  "identifier": {
                     "anyOf": [
                       {
-                        "description": "FS scope path.",
-                        "type": "string"
+                        "description": "This set of permissions describes the what kind of\nfile system access the `fs` plugin has enabled or denied by default.\n\n#### Granted Permissions\n\nThis default permission set enables read access to the\napplication specific directories (AppConfig, AppData, AppLocalData, AppCache,\nAppLog) and all files and sub directories created in it.\nThe location of these directories depends on the operating system,\nwhere the application is run.\n\nIn general these directories need to be manually created\nby the application at runtime, before accessing files or folders\nin it is possible.\n\nTherefore, it is also allowed to create all of these folders via\nthe `mkdir` command.\n\n#### Denied Permissions\n\nThis default permission set prevents access to critical components\nof the Tauri application by default.\nOn Windows the webview data folder access is denied.\n\n#### Included permissions within this default permission set:\n",
+                        "type": "string",
+                        "const": "fs:default"
                       },
                       {
-                        "type": "object",
-                        "required": ["path"],
-                        "properties": {
-                          "path": {
-                            "description": "FS scope path.",
-                            "type": "string"
-                          }
-                        }
-                      }
-                    ]
-                  }
-                },
-                "deny": {
-                  "items": {
-                    "title": "FsScopeEntry",
-                    "description": "FS scope entry.",
-                    "anyOf": [
-                      {
-                        "description": "FS scope path.",
-                        "type": "string"
+                        "description": "This allows non-recursive read access to metadata of the application folders, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-app-meta"
                       },
                       {
-                        "type": "object",
-                        "required": ["path"],
-                        "properties": {
-                          "path": {
-                            "description": "FS scope path.",
-                            "type": "string"
-                          }
-                        }
+                        "description": "This allows full recursive read access to metadata of the application folders, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-app-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the application folders.",
+                        "type": "string",
+                        "const": "fs:allow-app-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete application folders, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-app-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the application folders.",
+                        "type": "string",
+                        "const": "fs:allow-app-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete application folders, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-app-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-appcache-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-appcache-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$APPCACHE` folder.",
+                        "type": "string",
+                        "const": "fs:allow-appcache-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$APPCACHE` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-appcache-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$APPCACHE` folder.",
+                        "type": "string",
+                        "const": "fs:allow-appcache-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$APPCACHE` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-appcache-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-appconfig-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-appconfig-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$APPCONFIG` folder.",
+                        "type": "string",
+                        "const": "fs:allow-appconfig-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$APPCONFIG` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-appconfig-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$APPCONFIG` folder.",
+                        "type": "string",
+                        "const": "fs:allow-appconfig-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$APPCONFIG` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-appconfig-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-appdata-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-appdata-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$APPDATA` folder.",
+                        "type": "string",
+                        "const": "fs:allow-appdata-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$APPDATA` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-appdata-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$APPDATA` folder.",
+                        "type": "string",
+                        "const": "fs:allow-appdata-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$APPDATA` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-appdata-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-applocaldata-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-applocaldata-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$APPLOCALDATA` folder.",
+                        "type": "string",
+                        "const": "fs:allow-applocaldata-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$APPLOCALDATA` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-applocaldata-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$APPLOCALDATA` folder.",
+                        "type": "string",
+                        "const": "fs:allow-applocaldata-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$APPLOCALDATA` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-applocaldata-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-applog-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-applog-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$APPLOG` folder.",
+                        "type": "string",
+                        "const": "fs:allow-applog-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$APPLOG` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-applog-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$APPLOG` folder.",
+                        "type": "string",
+                        "const": "fs:allow-applog-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$APPLOG` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-applog-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-audio-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-audio-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$AUDIO` folder.",
+                        "type": "string",
+                        "const": "fs:allow-audio-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$AUDIO` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-audio-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$AUDIO` folder.",
+                        "type": "string",
+                        "const": "fs:allow-audio-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$AUDIO` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-audio-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-cache-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-cache-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$CACHE` folder.",
+                        "type": "string",
+                        "const": "fs:allow-cache-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$CACHE` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-cache-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$CACHE` folder.",
+                        "type": "string",
+                        "const": "fs:allow-cache-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$CACHE` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-cache-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-config-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-config-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$CONFIG` folder.",
+                        "type": "string",
+                        "const": "fs:allow-config-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$CONFIG` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-config-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$CONFIG` folder.",
+                        "type": "string",
+                        "const": "fs:allow-config-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$CONFIG` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-config-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$DATA` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-data-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$DATA` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-data-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$DATA` folder.",
+                        "type": "string",
+                        "const": "fs:allow-data-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$DATA` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-data-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$DATA` folder.",
+                        "type": "string",
+                        "const": "fs:allow-data-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$DATA` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-data-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-desktop-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-desktop-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$DESKTOP` folder.",
+                        "type": "string",
+                        "const": "fs:allow-desktop-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$DESKTOP` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-desktop-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$DESKTOP` folder.",
+                        "type": "string",
+                        "const": "fs:allow-desktop-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$DESKTOP` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-desktop-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-document-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-document-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$DOCUMENT` folder.",
+                        "type": "string",
+                        "const": "fs:allow-document-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$DOCUMENT` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-document-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$DOCUMENT` folder.",
+                        "type": "string",
+                        "const": "fs:allow-document-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$DOCUMENT` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-document-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-download-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-download-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$DOWNLOAD` folder.",
+                        "type": "string",
+                        "const": "fs:allow-download-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$DOWNLOAD` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-download-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$DOWNLOAD` folder.",
+                        "type": "string",
+                        "const": "fs:allow-download-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$DOWNLOAD` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-download-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$EXE` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-exe-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$EXE` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-exe-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$EXE` folder.",
+                        "type": "string",
+                        "const": "fs:allow-exe-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$EXE` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-exe-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$EXE` folder.",
+                        "type": "string",
+                        "const": "fs:allow-exe-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$EXE` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-exe-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$FONT` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-font-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$FONT` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-font-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$FONT` folder.",
+                        "type": "string",
+                        "const": "fs:allow-font-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$FONT` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-font-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$FONT` folder.",
+                        "type": "string",
+                        "const": "fs:allow-font-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$FONT` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-font-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$HOME` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-home-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$HOME` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-home-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$HOME` folder.",
+                        "type": "string",
+                        "const": "fs:allow-home-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$HOME` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-home-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$HOME` folder.",
+                        "type": "string",
+                        "const": "fs:allow-home-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$HOME` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-home-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-localdata-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-localdata-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$LOCALDATA` folder.",
+                        "type": "string",
+                        "const": "fs:allow-localdata-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$LOCALDATA` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-localdata-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$LOCALDATA` folder.",
+                        "type": "string",
+                        "const": "fs:allow-localdata-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$LOCALDATA` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-localdata-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$LOG` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-log-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$LOG` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-log-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$LOG` folder.",
+                        "type": "string",
+                        "const": "fs:allow-log-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$LOG` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-log-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$LOG` folder.",
+                        "type": "string",
+                        "const": "fs:allow-log-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$LOG` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-log-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-picture-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-picture-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$PICTURE` folder.",
+                        "type": "string",
+                        "const": "fs:allow-picture-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$PICTURE` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-picture-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$PICTURE` folder.",
+                        "type": "string",
+                        "const": "fs:allow-picture-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$PICTURE` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-picture-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-public-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-public-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$PUBLIC` folder.",
+                        "type": "string",
+                        "const": "fs:allow-public-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$PUBLIC` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-public-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$PUBLIC` folder.",
+                        "type": "string",
+                        "const": "fs:allow-public-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$PUBLIC` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-public-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-resource-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-resource-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$RESOURCE` folder.",
+                        "type": "string",
+                        "const": "fs:allow-resource-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$RESOURCE` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-resource-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$RESOURCE` folder.",
+                        "type": "string",
+                        "const": "fs:allow-resource-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$RESOURCE` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-resource-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-runtime-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-runtime-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$RUNTIME` folder.",
+                        "type": "string",
+                        "const": "fs:allow-runtime-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$RUNTIME` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-runtime-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$RUNTIME` folder.",
+                        "type": "string",
+                        "const": "fs:allow-runtime-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$RUNTIME` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-runtime-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-temp-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-temp-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$TEMP` folder.",
+                        "type": "string",
+                        "const": "fs:allow-temp-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$TEMP` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-temp-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$TEMP` folder.",
+                        "type": "string",
+                        "const": "fs:allow-temp-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$TEMP` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-temp-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-template-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-template-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$TEMPLATE` folder.",
+                        "type": "string",
+                        "const": "fs:allow-template-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$TEMPLATE` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-template-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$TEMPLATE` folder.",
+                        "type": "string",
+                        "const": "fs:allow-template-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$TEMPLATE` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-template-write-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-video-meta"
+                      },
+                      {
+                        "description": "This allows full recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.",
+                        "type": "string",
+                        "const": "fs:allow-video-meta-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive read access to the `$VIDEO` folder.",
+                        "type": "string",
+                        "const": "fs:allow-video-read"
+                      },
+                      {
+                        "description": "This allows full recursive read access to the complete `$VIDEO` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-video-read-recursive"
+                      },
+                      {
+                        "description": "This allows non-recursive write access to the `$VIDEO` folder.",
+                        "type": "string",
+                        "const": "fs:allow-video-write"
+                      },
+                      {
+                        "description": "This allows full recursive write access to the complete `$VIDEO` folder, files and subdirectories.",
+                        "type": "string",
+                        "const": "fs:allow-video-write-recursive"
+                      },
+                      {
+                        "description": "This denies access to dangerous Tauri relevant files and folders by default.",
+                        "type": "string",
+                        "const": "fs:deny-default"
+                      },
+                      {
+                        "description": "Enables the copy_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-copy-file"
+                      },
+                      {
+                        "description": "Enables the create command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-create"
+                      },
+                      {
+                        "description": "Enables the exists command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-exists"
+                      },
+                      {
+                        "description": "Enables the fstat command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-fstat"
+                      },
+                      {
+                        "description": "Enables the ftruncate command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-ftruncate"
+                      },
+                      {
+                        "description": "Enables the lstat command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-lstat"
+                      },
+                      {
+                        "description": "Enables the mkdir command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-mkdir"
+                      },
+                      {
+                        "description": "Enables the open command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-open"
+                      },
+                      {
+                        "description": "Enables the read command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-read"
+                      },
+                      {
+                        "description": "Enables the read_dir command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-read-dir"
+                      },
+                      {
+                        "description": "Enables the read_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-read-file"
+                      },
+                      {
+                        "description": "Enables the read_text_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-read-text-file"
+                      },
+                      {
+                        "description": "Enables the read_text_file_lines command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-read-text-file-lines"
+                      },
+                      {
+                        "description": "Enables the read_text_file_lines_next command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-read-text-file-lines-next"
+                      },
+                      {
+                        "description": "Enables the remove command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-remove"
+                      },
+                      {
+                        "description": "Enables the rename command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-rename"
+                      },
+                      {
+                        "description": "Enables the seek command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-seek"
+                      },
+                      {
+                        "description": "Enables the size command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-size"
+                      },
+                      {
+                        "description": "Enables the stat command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-stat"
+                      },
+                      {
+                        "description": "Enables the truncate command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-truncate"
+                      },
+                      {
+                        "description": "Enables the unwatch command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-unwatch"
+                      },
+                      {
+                        "description": "Enables the watch command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-watch"
+                      },
+                      {
+                        "description": "Enables the write command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-write"
+                      },
+                      {
+                        "description": "Enables the write_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-write-file"
+                      },
+                      {
+                        "description": "Enables the write_text_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-write-text-file"
+                      },
+                      {
+                        "description": "This permissions allows to create the application specific directories.\n",
+                        "type": "string",
+                        "const": "fs:create-app-specific-dirs"
+                      },
+                      {
+                        "description": "Denies the copy_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-copy-file"
+                      },
+                      {
+                        "description": "Denies the create command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-create"
+                      },
+                      {
+                        "description": "Denies the exists command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-exists"
+                      },
+                      {
+                        "description": "Denies the fstat command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-fstat"
+                      },
+                      {
+                        "description": "Denies the ftruncate command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-ftruncate"
+                      },
+                      {
+                        "description": "Denies the lstat command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-lstat"
+                      },
+                      {
+                        "description": "Denies the mkdir command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-mkdir"
+                      },
+                      {
+                        "description": "Denies the open command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-open"
+                      },
+                      {
+                        "description": "Denies the read command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-read"
+                      },
+                      {
+                        "description": "Denies the read_dir command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-read-dir"
+                      },
+                      {
+                        "description": "Denies the read_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-read-file"
+                      },
+                      {
+                        "description": "Denies the read_text_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-read-text-file"
+                      },
+                      {
+                        "description": "Denies the read_text_file_lines command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-read-text-file-lines"
+                      },
+                      {
+                        "description": "Denies the read_text_file_lines_next command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-read-text-file-lines-next"
+                      },
+                      {
+                        "description": "Denies the remove command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-remove"
+                      },
+                      {
+                        "description": "Denies the rename command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-rename"
+                      },
+                      {
+                        "description": "Denies the seek command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-seek"
+                      },
+                      {
+                        "description": "Denies the size command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-size"
+                      },
+                      {
+                        "description": "Denies the stat command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-stat"
+                      },
+                      {
+                        "description": "Denies the truncate command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-truncate"
+                      },
+                      {
+                        "description": "Denies the unwatch command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-unwatch"
+                      },
+                      {
+                        "description": "Denies the watch command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-watch"
+                      },
+                      {
+                        "description": "This denies read access to the\n`$APPLOCALDATA` folder on linux as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
+                        "type": "string",
+                        "const": "fs:deny-webview-data-linux"
+                      },
+                      {
+                        "description": "This denies read access to the\n`$APPLOCALDATA/EBWebView` folder on windows as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
+                        "type": "string",
+                        "const": "fs:deny-webview-data-windows"
+                      },
+                      {
+                        "description": "Denies the write command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-write"
+                      },
+                      {
+                        "description": "Denies the write_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-write-file"
+                      },
+                      {
+                        "description": "Denies the write_text_file command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-write-text-file"
+                      },
+                      {
+                        "description": "This enables all read related commands without any pre-configured accessible paths.",
+                        "type": "string",
+                        "const": "fs:read-all"
+                      },
+                      {
+                        "description": "This permission allows recursive read functionality on the application\nspecific base directories. \n",
+                        "type": "string",
+                        "const": "fs:read-app-specific-dirs-recursive"
+                      },
+                      {
+                        "description": "This enables directory read and file metadata related commands without any pre-configured accessible paths.",
+                        "type": "string",
+                        "const": "fs:read-dirs"
+                      },
+                      {
+                        "description": "This enables file read related commands without any pre-configured accessible paths.",
+                        "type": "string",
+                        "const": "fs:read-files"
+                      },
+                      {
+                        "description": "This enables all index or metadata related commands without any pre-configured accessible paths.",
+                        "type": "string",
+                        "const": "fs:read-meta"
+                      },
+                      {
+                        "description": "An empty permission you can use to modify the global scope.",
+                        "type": "string",
+                        "const": "fs:scope"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the application folders.",
+                        "type": "string",
+                        "const": "fs:scope-app"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the application directories.",
+                        "type": "string",
+                        "const": "fs:scope-app-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete application folders, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-app-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$APPCACHE` folder.",
+                        "type": "string",
+                        "const": "fs:scope-appcache"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$APPCACHE`folder.",
+                        "type": "string",
+                        "const": "fs:scope-appcache-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$APPCACHE` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-appcache-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$APPCONFIG` folder.",
+                        "type": "string",
+                        "const": "fs:scope-appconfig"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$APPCONFIG`folder.",
+                        "type": "string",
+                        "const": "fs:scope-appconfig-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$APPCONFIG` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-appconfig-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$APPDATA` folder.",
+                        "type": "string",
+                        "const": "fs:scope-appdata"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$APPDATA`folder.",
+                        "type": "string",
+                        "const": "fs:scope-appdata-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$APPDATA` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-appdata-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$APPLOCALDATA` folder.",
+                        "type": "string",
+                        "const": "fs:scope-applocaldata"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$APPLOCALDATA`folder.",
+                        "type": "string",
+                        "const": "fs:scope-applocaldata-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$APPLOCALDATA` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-applocaldata-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$APPLOG` folder.",
+                        "type": "string",
+                        "const": "fs:scope-applog"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$APPLOG`folder.",
+                        "type": "string",
+                        "const": "fs:scope-applog-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$APPLOG` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-applog-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$AUDIO` folder.",
+                        "type": "string",
+                        "const": "fs:scope-audio"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$AUDIO`folder.",
+                        "type": "string",
+                        "const": "fs:scope-audio-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$AUDIO` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-audio-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$CACHE` folder.",
+                        "type": "string",
+                        "const": "fs:scope-cache"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$CACHE`folder.",
+                        "type": "string",
+                        "const": "fs:scope-cache-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$CACHE` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-cache-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$CONFIG` folder.",
+                        "type": "string",
+                        "const": "fs:scope-config"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$CONFIG`folder.",
+                        "type": "string",
+                        "const": "fs:scope-config-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$CONFIG` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-config-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$DATA` folder.",
+                        "type": "string",
+                        "const": "fs:scope-data"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$DATA`folder.",
+                        "type": "string",
+                        "const": "fs:scope-data-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$DATA` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-data-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$DESKTOP` folder.",
+                        "type": "string",
+                        "const": "fs:scope-desktop"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$DESKTOP`folder.",
+                        "type": "string",
+                        "const": "fs:scope-desktop-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$DESKTOP` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-desktop-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$DOCUMENT` folder.",
+                        "type": "string",
+                        "const": "fs:scope-document"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$DOCUMENT`folder.",
+                        "type": "string",
+                        "const": "fs:scope-document-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$DOCUMENT` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-document-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$DOWNLOAD` folder.",
+                        "type": "string",
+                        "const": "fs:scope-download"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$DOWNLOAD`folder.",
+                        "type": "string",
+                        "const": "fs:scope-download-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$DOWNLOAD` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-download-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$EXE` folder.",
+                        "type": "string",
+                        "const": "fs:scope-exe"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$EXE`folder.",
+                        "type": "string",
+                        "const": "fs:scope-exe-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$EXE` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-exe-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$FONT` folder.",
+                        "type": "string",
+                        "const": "fs:scope-font"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$FONT`folder.",
+                        "type": "string",
+                        "const": "fs:scope-font-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$FONT` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-font-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$HOME` folder.",
+                        "type": "string",
+                        "const": "fs:scope-home"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$HOME`folder.",
+                        "type": "string",
+                        "const": "fs:scope-home-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$HOME` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-home-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$LOCALDATA` folder.",
+                        "type": "string",
+                        "const": "fs:scope-localdata"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$LOCALDATA`folder.",
+                        "type": "string",
+                        "const": "fs:scope-localdata-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$LOCALDATA` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-localdata-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$LOG` folder.",
+                        "type": "string",
+                        "const": "fs:scope-log"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$LOG`folder.",
+                        "type": "string",
+                        "const": "fs:scope-log-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$LOG` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-log-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$PICTURE` folder.",
+                        "type": "string",
+                        "const": "fs:scope-picture"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$PICTURE`folder.",
+                        "type": "string",
+                        "const": "fs:scope-picture-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$PICTURE` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-picture-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$PUBLIC` folder.",
+                        "type": "string",
+                        "const": "fs:scope-public"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$PUBLIC`folder.",
+                        "type": "string",
+                        "const": "fs:scope-public-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$PUBLIC` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-public-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$RESOURCE` folder.",
+                        "type": "string",
+                        "const": "fs:scope-resource"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$RESOURCE`folder.",
+                        "type": "string",
+                        "const": "fs:scope-resource-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$RESOURCE` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-resource-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$RUNTIME` folder.",
+                        "type": "string",
+                        "const": "fs:scope-runtime"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$RUNTIME`folder.",
+                        "type": "string",
+                        "const": "fs:scope-runtime-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$RUNTIME` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-runtime-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$TEMP` folder.",
+                        "type": "string",
+                        "const": "fs:scope-temp"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$TEMP`folder.",
+                        "type": "string",
+                        "const": "fs:scope-temp-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$TEMP` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-temp-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$TEMPLATE` folder.",
+                        "type": "string",
+                        "const": "fs:scope-template"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$TEMPLATE`folder.",
+                        "type": "string",
+                        "const": "fs:scope-template-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$TEMPLATE` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-template-recursive"
+                      },
+                      {
+                        "description": "This scope permits access to all files and list content of top level directories in the `$VIDEO` folder.",
+                        "type": "string",
+                        "const": "fs:scope-video"
+                      },
+                      {
+                        "description": "This scope permits to list all files and folders in the `$VIDEO`folder.",
+                        "type": "string",
+                        "const": "fs:scope-video-index"
+                      },
+                      {
+                        "description": "This scope permits recursive access to the complete `$VIDEO` folder, including sub directories and files.",
+                        "type": "string",
+                        "const": "fs:scope-video-recursive"
+                      },
+                      {
+                        "description": "This enables all write related commands without any pre-configured accessible paths.",
+                        "type": "string",
+                        "const": "fs:write-all"
+                      },
+                      {
+                        "description": "This enables all file write related commands without any pre-configured accessible paths.",
+                        "type": "string",
+                        "const": "fs:write-files"
                       }
                     ]
                   }
                 }
-              }
-            },
-            {
-              "type": "object",
-              "required": ["identifier"],
+              },
+              "then": {
+                "properties": {
+                  "allow": {
+                    "items": {
+                      "title": "FsScopeEntry",
+                      "description": "FS scope entry.",
+                      "anyOf": [
+                        {
+                          "description": "A path that can be accessed by the webview when using the fs APIs. FS scope path pattern.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                          "type": "string"
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "path"
+                          ],
+                          "properties": {
+                            "path": {
+                              "description": "A path that can be accessed by the webview when using the fs APIs.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "deny": {
+                    "items": {
+                      "title": "FsScopeEntry",
+                      "description": "FS scope entry.",
+                      "anyOf": [
+                        {
+                          "description": "A path that can be accessed by the webview when using the fs APIs. FS scope path pattern.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                          "type": "string"
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "path"
+                          ],
+                          "properties": {
+                            "path": {
+                              "description": "A path that can be accessed by the webview when using the fs APIs.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
               "properties": {
                 "identifier": {
-                  "oneOf": [
+                  "description": "Identifier of the permission or permission set.",
+                  "allOf": [
                     {
-                      "description": "http:default -> This permission set configures what kind of\nfetch operations are available from the http plugin.\n\nThis enables all fetch operations but does not\nallow explicitly any origins to be fetched. This needs to\nbe manually configured before usage.\n\n#### Granted Permissions\n\nAll fetch operations are enabled.\n\n",
-                      "type": "string",
-                      "enum": ["http:default"]
-                    },
-                    {
-                      "description": "http:allow-fetch -> Enables the fetch command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["http:allow-fetch"]
-                    },
-                    {
-                      "description": "http:allow-fetch-cancel -> Enables the fetch_cancel command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["http:allow-fetch-cancel"]
-                    },
-                    {
-                      "description": "http:allow-fetch-read-body -> Enables the fetch_read_body command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["http:allow-fetch-read-body"]
-                    },
-                    {
-                      "description": "http:allow-fetch-send -> Enables the fetch_send command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["http:allow-fetch-send"]
-                    },
-                    {
-                      "description": "http:deny-fetch -> Denies the fetch command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["http:deny-fetch"]
-                    },
-                    {
-                      "description": "http:deny-fetch-cancel -> Denies the fetch_cancel command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["http:deny-fetch-cancel"]
-                    },
-                    {
-                      "description": "http:deny-fetch-read-body -> Denies the fetch_read_body command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["http:deny-fetch-read-body"]
-                    },
-                    {
-                      "description": "http:deny-fetch-send -> Denies the fetch_send command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["http:deny-fetch-send"]
+                      "$ref": "#/definitions/Identifier"
                     }
                   ]
-                },
-                "allow": {
-                  "items": {
-                    "title": "HttpScopeEntry",
-                    "description": "HTTP scope entry.",
-                    "anyOf": [
-                      {
-                        "description": "A URL that can be accessed by the webview when using the HTTP APIs. Wildcards can be used following the URL pattern standard.\n\nSee [the URL Pattern spec](https://urlpattern.spec.whatwg.org/) for more information.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin on port 443\n\n- \"https://*:*\" : allows all HTTPS origin on any port\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
-                        "type": "string"
-                      },
-                      {
-                        "type": "object",
-                        "required": ["url"],
-                        "properties": {
-                          "url": {
-                            "description": "A URL that can be accessed by the webview when using the HTTP APIs. Wildcards can be used following the URL pattern standard.\n\nSee [the URL Pattern spec](https://urlpattern.spec.whatwg.org/) for more information.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin on port 443\n\n- \"https://*:*\" : allows all HTTPS origin on any port\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
-                            "type": "string"
-                          }
-                        }
-                      }
-                    ]
-                  }
-                },
-                "deny": {
-                  "items": {
-                    "title": "HttpScopeEntry",
-                    "description": "HTTP scope entry.",
-                    "anyOf": [
-                      {
-                        "description": "A URL that can be accessed by the webview when using the HTTP APIs. Wildcards can be used following the URL pattern standard.\n\nSee [the URL Pattern spec](https://urlpattern.spec.whatwg.org/) for more information.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin on port 443\n\n- \"https://*:*\" : allows all HTTPS origin on any port\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
-                        "type": "string"
-                      },
-                      {
-                        "type": "object",
-                        "required": ["url"],
-                        "properties": {
-                          "url": {
-                            "description": "A URL that can be accessed by the webview when using the HTTP APIs. Wildcards can be used following the URL pattern standard.\n\nSee [the URL Pattern spec](https://urlpattern.spec.whatwg.org/) for more information.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin on port 443\n\n- \"https://*:*\" : allows all HTTPS origin on any port\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
-                            "type": "string"
-                          }
-                        }
-                      }
-                    ]
-                  }
                 }
               }
             },
             {
-              "type": "object",
-              "required": ["identifier"],
+              "if": {
+                "properties": {
+                  "identifier": {
+                    "anyOf": [
+                      {
+                        "description": "This permission set configures what kind of\nfetch operations are available from the http plugin.\n\nThis enables all fetch operations but does not\nallow explicitly any origins to be fetched. This needs to\nbe manually configured before usage.\n\n#### Granted Permissions\n\nAll fetch operations are enabled.\n\n",
+                        "type": "string",
+                        "const": "http:default"
+                      },
+                      {
+                        "description": "Enables the fetch command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "http:allow-fetch"
+                      },
+                      {
+                        "description": "Enables the fetch_cancel command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "http:allow-fetch-cancel"
+                      },
+                      {
+                        "description": "Enables the fetch_read_body command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "http:allow-fetch-read-body"
+                      },
+                      {
+                        "description": "Enables the fetch_send command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "http:allow-fetch-send"
+                      },
+                      {
+                        "description": "Denies the fetch command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "http:deny-fetch"
+                      },
+                      {
+                        "description": "Denies the fetch_cancel command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "http:deny-fetch-cancel"
+                      },
+                      {
+                        "description": "Denies the fetch_read_body command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "http:deny-fetch-read-body"
+                      },
+                      {
+                        "description": "Denies the fetch_send command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "http:deny-fetch-send"
+                      }
+                    ]
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "allow": {
+                    "items": {
+                      "title": "HttpScopeEntry",
+                      "description": "HTTP scope entry.",
+                      "anyOf": [
+                        {
+                          "description": "A URL that can be accessed by the webview when using the HTTP APIs. Wildcards can be used following the URL pattern standard.\n\nSee [the URL Pattern spec](https://urlpattern.spec.whatwg.org/) for more information.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin on port 443\n\n- \"https://*:*\" : allows all HTTPS origin on any port\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
+                          "type": "string"
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "url"
+                          ],
+                          "properties": {
+                            "url": {
+                              "description": "A URL that can be accessed by the webview when using the HTTP APIs. Wildcards can be used following the URL pattern standard.\n\nSee [the URL Pattern spec](https://urlpattern.spec.whatwg.org/) for more information.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin on port 443\n\n- \"https://*:*\" : allows all HTTPS origin on any port\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "deny": {
+                    "items": {
+                      "title": "HttpScopeEntry",
+                      "description": "HTTP scope entry.",
+                      "anyOf": [
+                        {
+                          "description": "A URL that can be accessed by the webview when using the HTTP APIs. Wildcards can be used following the URL pattern standard.\n\nSee [the URL Pattern spec](https://urlpattern.spec.whatwg.org/) for more information.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin on port 443\n\n- \"https://*:*\" : allows all HTTPS origin on any port\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
+                          "type": "string"
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "url"
+                          ],
+                          "properties": {
+                            "url": {
+                              "description": "A URL that can be accessed by the webview when using the HTTP APIs. Wildcards can be used following the URL pattern standard.\n\nSee [the URL Pattern spec](https://urlpattern.spec.whatwg.org/) for more information.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin on port 443\n\n- \"https://*:*\" : allows all HTTPS origin on any port\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
               "properties": {
                 "identifier": {
-                  "oneOf": [
+                  "description": "Identifier of the permission or permission set.",
+                  "allOf": [
                     {
-                      "description": "shell:default -> This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality without any specific\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n",
-                      "type": "string",
-                      "enum": ["shell:default"]
-                    },
+                      "$ref": "#/definitions/Identifier"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "identifier": {
+                    "anyOf": [
+                      {
+                        "description": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality without any specific\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n",
+                        "type": "string",
+                        "const": "shell:default"
+                      },
+                      {
+                        "description": "Enables the execute command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:allow-execute"
+                      },
+                      {
+                        "description": "Enables the kill command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:allow-kill"
+                      },
+                      {
+                        "description": "Enables the open command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:allow-open"
+                      },
+                      {
+                        "description": "Enables the spawn command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:allow-spawn"
+                      },
+                      {
+                        "description": "Enables the stdin_write command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:allow-stdin-write"
+                      },
+                      {
+                        "description": "Denies the execute command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:deny-execute"
+                      },
+                      {
+                        "description": "Denies the kill command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:deny-kill"
+                      },
+                      {
+                        "description": "Denies the open command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:deny-open"
+                      },
+                      {
+                        "description": "Denies the spawn command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:deny-spawn"
+                      },
+                      {
+                        "description": "Denies the stdin_write command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "shell:deny-stdin-write"
+                      }
+                    ]
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "allow": {
+                    "items": {
+                      "title": "ShellScopeEntry",
+                      "description": "Shell scope entry.",
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "required": [
+                            "cmd",
+                            "name"
+                          ],
+                          "properties": {
+                            "args": {
+                              "description": "The allowed arguments for the command execution.",
+                              "allOf": [
+                                {
+                                  "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
+                                }
+                              ]
+                            },
+                            "cmd": {
+                              "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "sidecar"
+                          ],
+                          "properties": {
+                            "args": {
+                              "description": "The allowed arguments for the command execution.",
+                              "allOf": [
+                                {
+                                  "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
+                                }
+                              ]
+                            },
+                            "name": {
+                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                              "type": "string"
+                            },
+                            "sidecar": {
+                              "description": "If this command is a sidecar command.",
+                              "type": "boolean"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "deny": {
+                    "items": {
+                      "title": "ShellScopeEntry",
+                      "description": "Shell scope entry.",
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "required": [
+                            "cmd",
+                            "name"
+                          ],
+                          "properties": {
+                            "args": {
+                              "description": "The allowed arguments for the command execution.",
+                              "allOf": [
+                                {
+                                  "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
+                                }
+                              ]
+                            },
+                            "cmd": {
+                              "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "sidecar"
+                          ],
+                          "properties": {
+                            "args": {
+                              "description": "The allowed arguments for the command execution.",
+                              "allOf": [
+                                {
+                                  "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
+                                }
+                              ]
+                            },
+                            "name": {
+                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                              "type": "string"
+                            },
+                            "sidecar": {
+                              "description": "If this command is a sidecar command.",
+                              "type": "boolean"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "properties": {
+                "identifier": {
+                  "description": "Identifier of the permission or permission set.",
+                  "allOf": [
                     {
-                      "description": "shell:allow-execute -> Enables the execute command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["shell:allow-execute"]
-                    },
+                      "$ref": "#/definitions/Identifier"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "properties": {
+                "identifier": {
+                  "description": "Identifier of the permission or permission set.",
+                  "allOf": [
                     {
-                      "description": "shell:allow-kill -> Enables the kill command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["shell:allow-kill"]
-                    },
-                    {
-                      "description": "shell:allow-open -> Enables the open command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["shell:allow-open"]
-                    },
-                    {
-                      "description": "shell:allow-spawn -> Enables the spawn command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["shell:allow-spawn"]
-                    },
-                    {
-                      "description": "shell:allow-stdin-write -> Enables the stdin_write command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["shell:allow-stdin-write"]
-                    },
-                    {
-                      "description": "shell:deny-execute -> Denies the execute command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["shell:deny-execute"]
-                    },
-                    {
-                      "description": "shell:deny-kill -> Denies the kill command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["shell:deny-kill"]
-                    },
-                    {
-                      "description": "shell:deny-open -> Denies the open command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["shell:deny-open"]
-                    },
-                    {
-                      "description": "shell:deny-spawn -> Denies the spawn command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["shell:deny-spawn"]
-                    },
-                    {
-                      "description": "shell:deny-stdin-write -> Denies the stdin_write command without any pre-configured scope.",
-                      "type": "string",
-                      "enum": ["shell:deny-stdin-write"]
+                      "$ref": "#/definitions/Identifier"
                     }
                   ]
                 },
                 "allow": {
+                  "description": "Data that defines what is allowed by the scope.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
                   "items": {
-                    "title": "Entry",
-                    "description": "A command allowed to be executed by the webview API.",
-                    "type": "object",
-                    "required": ["args", "cmd", "name", "sidecar"],
-                    "properties": {
-                      "args": {
-                        "description": "The allowed arguments for the command execution.",
-                        "allOf": [
-                          {
-                            "$ref": "#/definitions/ShellAllowedArgs"
-                          }
-                        ]
-                      },
-                      "cmd": {
-                        "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
-                        "type": "string"
-                      },
-                      "sidecar": {
-                        "description": "If this command is a sidecar command.",
-                        "type": "boolean"
-                      }
-                    }
+                    "$ref": "#/definitions/Value"
                   }
                 },
                 "deny": {
+                  "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+                  "type": [
+                    "array",
+                    "null"
+                  ],
                   "items": {
-                    "title": "Entry",
-                    "description": "A command allowed to be executed by the webview API.",
-                    "type": "object",
-                    "required": ["args", "cmd", "name", "sidecar"],
-                    "properties": {
-                      "args": {
-                        "description": "The allowed arguments for the command execution.",
-                        "allOf": [
-                          {
-                            "$ref": "#/definitions/ShellAllowedArgs"
-                          }
-                        ]
-                      },
-                      "cmd": {
-                        "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
-                        "type": "string"
-                      },
-                      "sidecar": {
-                        "description": "If this command is a sidecar command.",
-                        "type": "boolean"
-                      }
-                    }
+                    "$ref": "#/definitions/Value"
                   }
                 }
               }
             }
+          ],
+          "required": [
+            "identifier"
           ]
         }
       ]
     },
     "Identifier": {
+      "description": "Permission identifier",
       "oneOf": [
         {
-          "description": "core:app:default -> Default permissions for the plugin.",
+          "description": "Default core plugins set which includes:\n- 'core:path:default'\n- 'core:event:default'\n- 'core:window:default'\n- 'core:webview:default'\n- 'core:app:default'\n- 'core:image:default'\n- 'core:resources:default'\n- 'core:menu:default'\n- 'core:tray:default'\n",
           "type": "string",
-          "enum": ["core:app:default"]
+          "const": "core:default"
         },
         {
-          "description": "core:app:allow-app-hide -> Enables the app_hide command without any pre-configured scope.",
+          "description": "Default permissions for the plugin.",
           "type": "string",
-          "enum": ["core:app:allow-app-hide"]
+          "const": "core:app:default"
         },
         {
-          "description": "core:app:allow-app-show -> Enables the app_show command without any pre-configured scope.",
+          "description": "Enables the app_hide command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:app:allow-app-show"]
+          "const": "core:app:allow-app-hide"
         },
         {
-          "description": "core:app:allow-default-window-icon -> Enables the default_window_icon command without any pre-configured scope.",
+          "description": "Enables the app_show command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:app:allow-default-window-icon"]
+          "const": "core:app:allow-app-show"
         },
         {
-          "description": "core:app:allow-name -> Enables the name command without any pre-configured scope.",
+          "description": "Enables the default_window_icon command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:app:allow-name"]
+          "const": "core:app:allow-default-window-icon"
         },
         {
-          "description": "core:app:allow-tauri-version -> Enables the tauri_version command without any pre-configured scope.",
+          "description": "Enables the name command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:app:allow-tauri-version"]
+          "const": "core:app:allow-name"
         },
         {
-          "description": "core:app:allow-version -> Enables the version command without any pre-configured scope.",
+          "description": "Enables the set_app_theme command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:app:allow-version"]
+          "const": "core:app:allow-set-app-theme"
         },
         {
-          "description": "core:app:deny-app-hide -> Denies the app_hide command without any pre-configured scope.",
+          "description": "Enables the tauri_version command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:app:deny-app-hide"]
+          "const": "core:app:allow-tauri-version"
         },
         {
-          "description": "core:app:deny-app-show -> Denies the app_show command without any pre-configured scope.",
+          "description": "Enables the version command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:app:deny-app-show"]
+          "const": "core:app:allow-version"
         },
         {
-          "description": "core:app:deny-default-window-icon -> Denies the default_window_icon command without any pre-configured scope.",
+          "description": "Denies the app_hide command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:app:deny-default-window-icon"]
+          "const": "core:app:deny-app-hide"
         },
         {
-          "description": "core:app:deny-name -> Denies the name command without any pre-configured scope.",
+          "description": "Denies the app_show command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:app:deny-name"]
+          "const": "core:app:deny-app-show"
         },
         {
-          "description": "core:app:deny-tauri-version -> Denies the tauri_version command without any pre-configured scope.",
+          "description": "Denies the default_window_icon command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:app:deny-tauri-version"]
+          "const": "core:app:deny-default-window-icon"
         },
         {
-          "description": "core:app:deny-version -> Denies the version command without any pre-configured scope.",
+          "description": "Denies the name command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:app:deny-version"]
+          "const": "core:app:deny-name"
         },
         {
-          "description": "core:event:default -> Default permissions for the plugin.",
+          "description": "Denies the set_app_theme command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:event:default"]
+          "const": "core:app:deny-set-app-theme"
         },
         {
-          "description": "core:event:allow-emit -> Enables the emit command without any pre-configured scope.",
+          "description": "Denies the tauri_version command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:event:allow-emit"]
+          "const": "core:app:deny-tauri-version"
         },
         {
-          "description": "core:event:allow-emit-to -> Enables the emit_to command without any pre-configured scope.",
+          "description": "Denies the version command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:event:allow-emit-to"]
+          "const": "core:app:deny-version"
         },
         {
-          "description": "core:event:allow-listen -> Enables the listen command without any pre-configured scope.",
+          "description": "Default permissions for the plugin.",
           "type": "string",
-          "enum": ["core:event:allow-listen"]
+          "const": "core:event:default"
         },
         {
-          "description": "core:event:allow-unlisten -> Enables the unlisten command without any pre-configured scope.",
+          "description": "Enables the emit command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:event:allow-unlisten"]
+          "const": "core:event:allow-emit"
         },
         {
-          "description": "core:event:deny-emit -> Denies the emit command without any pre-configured scope.",
+          "description": "Enables the emit_to command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:event:deny-emit"]
+          "const": "core:event:allow-emit-to"
         },
         {
-          "description": "core:event:deny-emit-to -> Denies the emit_to command without any pre-configured scope.",
+          "description": "Enables the listen command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:event:deny-emit-to"]
+          "const": "core:event:allow-listen"
         },
         {
-          "description": "core:event:deny-listen -> Denies the listen command without any pre-configured scope.",
+          "description": "Enables the unlisten command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:event:deny-listen"]
+          "const": "core:event:allow-unlisten"
         },
         {
-          "description": "core:event:deny-unlisten -> Denies the unlisten command without any pre-configured scope.",
+          "description": "Denies the emit command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:event:deny-unlisten"]
+          "const": "core:event:deny-emit"
         },
         {
-          "description": "core:image:default -> Default permissions for the plugin.",
+          "description": "Denies the emit_to command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:image:default"]
+          "const": "core:event:deny-emit-to"
         },
         {
-          "description": "core:image:allow-from-bytes -> Enables the from_bytes command without any pre-configured scope.",
+          "description": "Denies the listen command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:image:allow-from-bytes"]
+          "const": "core:event:deny-listen"
         },
         {
-          "description": "core:image:allow-from-path -> Enables the from_path command without any pre-configured scope.",
+          "description": "Denies the unlisten command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:image:allow-from-path"]
+          "const": "core:event:deny-unlisten"
         },
         {
-          "description": "core:image:allow-new -> Enables the new command without any pre-configured scope.",
+          "description": "Default permissions for the plugin.",
           "type": "string",
-          "enum": ["core:image:allow-new"]
+          "const": "core:image:default"
         },
         {
-          "description": "core:image:allow-rgba -> Enables the rgba command without any pre-configured scope.",
+          "description": "Enables the from_bytes command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:image:allow-rgba"]
+          "const": "core:image:allow-from-bytes"
         },
         {
-          "description": "core:image:allow-size -> Enables the size command without any pre-configured scope.",
+          "description": "Enables the from_path command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:image:allow-size"]
+          "const": "core:image:allow-from-path"
         },
         {
-          "description": "core:image:deny-from-bytes -> Denies the from_bytes command without any pre-configured scope.",
+          "description": "Enables the new command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:image:deny-from-bytes"]
+          "const": "core:image:allow-new"
         },
         {
-          "description": "core:image:deny-from-path -> Denies the from_path command without any pre-configured scope.",
+          "description": "Enables the rgba command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:image:deny-from-path"]
+          "const": "core:image:allow-rgba"
         },
         {
-          "description": "core:image:deny-new -> Denies the new command without any pre-configured scope.",
+          "description": "Enables the size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:image:deny-new"]
+          "const": "core:image:allow-size"
         },
         {
-          "description": "core:image:deny-rgba -> Denies the rgba command without any pre-configured scope.",
+          "description": "Denies the from_bytes command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:image:deny-rgba"]
+          "const": "core:image:deny-from-bytes"
         },
         {
-          "description": "core:image:deny-size -> Denies the size command without any pre-configured scope.",
+          "description": "Denies the from_path command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:image:deny-size"]
+          "const": "core:image:deny-from-path"
         },
         {
-          "description": "core:menu:default -> Default permissions for the plugin.",
+          "description": "Denies the new command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:default"]
+          "const": "core:image:deny-new"
         },
         {
-          "description": "core:menu:allow-append -> Enables the append command without any pre-configured scope.",
+          "description": "Denies the rgba command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-append"]
+          "const": "core:image:deny-rgba"
         },
         {
-          "description": "core:menu:allow-create-default -> Enables the create_default command without any pre-configured scope.",
+          "description": "Denies the size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-create-default"]
+          "const": "core:image:deny-size"
         },
         {
-          "description": "core:menu:allow-get -> Enables the get command without any pre-configured scope.",
+          "description": "Default permissions for the plugin.",
           "type": "string",
-          "enum": ["core:menu:allow-get"]
+          "const": "core:menu:default"
         },
         {
-          "description": "core:menu:allow-insert -> Enables the insert command without any pre-configured scope.",
+          "description": "Enables the append command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-insert"]
+          "const": "core:menu:allow-append"
         },
         {
-          "description": "core:menu:allow-is-checked -> Enables the is_checked command without any pre-configured scope.",
+          "description": "Enables the create_default command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-is-checked"]
+          "const": "core:menu:allow-create-default"
         },
         {
-          "description": "core:menu:allow-is-enabled -> Enables the is_enabled command without any pre-configured scope.",
+          "description": "Enables the get command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-is-enabled"]
+          "const": "core:menu:allow-get"
         },
         {
-          "description": "core:menu:allow-items -> Enables the items command without any pre-configured scope.",
+          "description": "Enables the insert command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-items"]
+          "const": "core:menu:allow-insert"
         },
         {
-          "description": "core:menu:allow-new -> Enables the new command without any pre-configured scope.",
+          "description": "Enables the is_checked command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-new"]
+          "const": "core:menu:allow-is-checked"
         },
         {
-          "description": "core:menu:allow-popup -> Enables the popup command without any pre-configured scope.",
+          "description": "Enables the is_enabled command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-popup"]
+          "const": "core:menu:allow-is-enabled"
         },
         {
-          "description": "core:menu:allow-prepend -> Enables the prepend command without any pre-configured scope.",
+          "description": "Enables the items command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-prepend"]
+          "const": "core:menu:allow-items"
         },
         {
-          "description": "core:menu:allow-remove -> Enables the remove command without any pre-configured scope.",
+          "description": "Enables the new command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-remove"]
+          "const": "core:menu:allow-new"
         },
         {
-          "description": "core:menu:allow-remove-at -> Enables the remove_at command without any pre-configured scope.",
+          "description": "Enables the popup command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-remove-at"]
+          "const": "core:menu:allow-popup"
         },
         {
-          "description": "core:menu:allow-set-accelerator -> Enables the set_accelerator command without any pre-configured scope.",
+          "description": "Enables the prepend command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-set-accelerator"]
+          "const": "core:menu:allow-prepend"
         },
         {
-          "description": "core:menu:allow-set-as-app-menu -> Enables the set_as_app_menu command without any pre-configured scope.",
+          "description": "Enables the remove command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-set-as-app-menu"]
+          "const": "core:menu:allow-remove"
         },
         {
-          "description": "core:menu:allow-set-as-help-menu-for-nsapp -> Enables the set_as_help_menu_for_nsapp command without any pre-configured scope.",
+          "description": "Enables the remove_at command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-set-as-help-menu-for-nsapp"]
+          "const": "core:menu:allow-remove-at"
         },
         {
-          "description": "core:menu:allow-set-as-window-menu -> Enables the set_as_window_menu command without any pre-configured scope.",
+          "description": "Enables the set_accelerator command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-set-as-window-menu"]
+          "const": "core:menu:allow-set-accelerator"
         },
         {
-          "description": "core:menu:allow-set-as-windows-menu-for-nsapp -> Enables the set_as_windows_menu_for_nsapp command without any pre-configured scope.",
+          "description": "Enables the set_as_app_menu command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-set-as-windows-menu-for-nsapp"]
+          "const": "core:menu:allow-set-as-app-menu"
         },
         {
-          "description": "core:menu:allow-set-checked -> Enables the set_checked command without any pre-configured scope.",
+          "description": "Enables the set_as_help_menu_for_nsapp command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-set-checked"]
+          "const": "core:menu:allow-set-as-help-menu-for-nsapp"
         },
         {
-          "description": "core:menu:allow-set-enabled -> Enables the set_enabled command without any pre-configured scope.",
+          "description": "Enables the set_as_window_menu command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-set-enabled"]
+          "const": "core:menu:allow-set-as-window-menu"
         },
         {
-          "description": "core:menu:allow-set-icon -> Enables the set_icon command without any pre-configured scope.",
+          "description": "Enables the set_as_windows_menu_for_nsapp command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-set-icon"]
+          "const": "core:menu:allow-set-as-windows-menu-for-nsapp"
         },
         {
-          "description": "core:menu:allow-set-text -> Enables the set_text command without any pre-configured scope.",
+          "description": "Enables the set_checked command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-set-text"]
+          "const": "core:menu:allow-set-checked"
         },
         {
-          "description": "core:menu:allow-text -> Enables the text command without any pre-configured scope.",
+          "description": "Enables the set_enabled command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:allow-text"]
+          "const": "core:menu:allow-set-enabled"
         },
         {
-          "description": "core:menu:deny-append -> Denies the append command without any pre-configured scope.",
+          "description": "Enables the set_icon command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-append"]
+          "const": "core:menu:allow-set-icon"
         },
         {
-          "description": "core:menu:deny-create-default -> Denies the create_default command without any pre-configured scope.",
+          "description": "Enables the set_text command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-create-default"]
+          "const": "core:menu:allow-set-text"
         },
         {
-          "description": "core:menu:deny-get -> Denies the get command without any pre-configured scope.",
+          "description": "Enables the text command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-get"]
+          "const": "core:menu:allow-text"
         },
         {
-          "description": "core:menu:deny-insert -> Denies the insert command without any pre-configured scope.",
+          "description": "Denies the append command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-insert"]
+          "const": "core:menu:deny-append"
         },
         {
-          "description": "core:menu:deny-is-checked -> Denies the is_checked command without any pre-configured scope.",
+          "description": "Denies the create_default command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-is-checked"]
+          "const": "core:menu:deny-create-default"
         },
         {
-          "description": "core:menu:deny-is-enabled -> Denies the is_enabled command without any pre-configured scope.",
+          "description": "Denies the get command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-is-enabled"]
+          "const": "core:menu:deny-get"
         },
         {
-          "description": "core:menu:deny-items -> Denies the items command without any pre-configured scope.",
+          "description": "Denies the insert command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-items"]
+          "const": "core:menu:deny-insert"
         },
         {
-          "description": "core:menu:deny-new -> Denies the new command without any pre-configured scope.",
+          "description": "Denies the is_checked command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-new"]
+          "const": "core:menu:deny-is-checked"
         },
         {
-          "description": "core:menu:deny-popup -> Denies the popup command without any pre-configured scope.",
+          "description": "Denies the is_enabled command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-popup"]
+          "const": "core:menu:deny-is-enabled"
         },
         {
-          "description": "core:menu:deny-prepend -> Denies the prepend command without any pre-configured scope.",
+          "description": "Denies the items command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-prepend"]
+          "const": "core:menu:deny-items"
         },
         {
-          "description": "core:menu:deny-remove -> Denies the remove command without any pre-configured scope.",
+          "description": "Denies the new command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-remove"]
+          "const": "core:menu:deny-new"
         },
         {
-          "description": "core:menu:deny-remove-at -> Denies the remove_at command without any pre-configured scope.",
+          "description": "Denies the popup command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-remove-at"]
+          "const": "core:menu:deny-popup"
         },
         {
-          "description": "core:menu:deny-set-accelerator -> Denies the set_accelerator command without any pre-configured scope.",
+          "description": "Denies the prepend command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-set-accelerator"]
+          "const": "core:menu:deny-prepend"
         },
         {
-          "description": "core:menu:deny-set-as-app-menu -> Denies the set_as_app_menu command without any pre-configured scope.",
+          "description": "Denies the remove command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-set-as-app-menu"]
+          "const": "core:menu:deny-remove"
         },
         {
-          "description": "core:menu:deny-set-as-help-menu-for-nsapp -> Denies the set_as_help_menu_for_nsapp command without any pre-configured scope.",
+          "description": "Denies the remove_at command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-set-as-help-menu-for-nsapp"]
+          "const": "core:menu:deny-remove-at"
         },
         {
-          "description": "core:menu:deny-set-as-window-menu -> Denies the set_as_window_menu command without any pre-configured scope.",
+          "description": "Denies the set_accelerator command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-set-as-window-menu"]
+          "const": "core:menu:deny-set-accelerator"
         },
         {
-          "description": "core:menu:deny-set-as-windows-menu-for-nsapp -> Denies the set_as_windows_menu_for_nsapp command without any pre-configured scope.",
+          "description": "Denies the set_as_app_menu command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-set-as-windows-menu-for-nsapp"]
+          "const": "core:menu:deny-set-as-app-menu"
         },
         {
-          "description": "core:menu:deny-set-checked -> Denies the set_checked command without any pre-configured scope.",
+          "description": "Denies the set_as_help_menu_for_nsapp command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-set-checked"]
+          "const": "core:menu:deny-set-as-help-menu-for-nsapp"
         },
         {
-          "description": "core:menu:deny-set-enabled -> Denies the set_enabled command without any pre-configured scope.",
+          "description": "Denies the set_as_window_menu command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-set-enabled"]
+          "const": "core:menu:deny-set-as-window-menu"
         },
         {
-          "description": "core:menu:deny-set-icon -> Denies the set_icon command without any pre-configured scope.",
+          "description": "Denies the set_as_windows_menu_for_nsapp command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-set-icon"]
+          "const": "core:menu:deny-set-as-windows-menu-for-nsapp"
         },
         {
-          "description": "core:menu:deny-set-text -> Denies the set_text command without any pre-configured scope.",
+          "description": "Denies the set_checked command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-set-text"]
+          "const": "core:menu:deny-set-checked"
         },
         {
-          "description": "core:menu:deny-text -> Denies the text command without any pre-configured scope.",
+          "description": "Denies the set_enabled command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:menu:deny-text"]
+          "const": "core:menu:deny-set-enabled"
         },
         {
-          "description": "core:path:default -> Default permissions for the plugin.",
+          "description": "Denies the set_icon command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:default"]
+          "const": "core:menu:deny-set-icon"
         },
         {
-          "description": "core:path:allow-basename -> Enables the basename command without any pre-configured scope.",
+          "description": "Denies the set_text command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:allow-basename"]
+          "const": "core:menu:deny-set-text"
         },
         {
-          "description": "core:path:allow-dirname -> Enables the dirname command without any pre-configured scope.",
+          "description": "Denies the text command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:allow-dirname"]
+          "const": "core:menu:deny-text"
         },
         {
-          "description": "core:path:allow-extname -> Enables the extname command without any pre-configured scope.",
+          "description": "Default permissions for the plugin.",
           "type": "string",
-          "enum": ["core:path:allow-extname"]
+          "const": "core:path:default"
         },
         {
-          "description": "core:path:allow-is-absolute -> Enables the is_absolute command without any pre-configured scope.",
+          "description": "Enables the basename command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:allow-is-absolute"]
+          "const": "core:path:allow-basename"
         },
         {
-          "description": "core:path:allow-join -> Enables the join command without any pre-configured scope.",
+          "description": "Enables the dirname command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:allow-join"]
+          "const": "core:path:allow-dirname"
         },
         {
-          "description": "core:path:allow-normalize -> Enables the normalize command without any pre-configured scope.",
+          "description": "Enables the extname command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:allow-normalize"]
+          "const": "core:path:allow-extname"
         },
         {
-          "description": "core:path:allow-resolve -> Enables the resolve command without any pre-configured scope.",
+          "description": "Enables the is_absolute command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:allow-resolve"]
+          "const": "core:path:allow-is-absolute"
         },
         {
-          "description": "core:path:allow-resolve-directory -> Enables the resolve_directory command without any pre-configured scope.",
+          "description": "Enables the join command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:allow-resolve-directory"]
+          "const": "core:path:allow-join"
         },
         {
-          "description": "core:path:deny-basename -> Denies the basename command without any pre-configured scope.",
+          "description": "Enables the normalize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:deny-basename"]
+          "const": "core:path:allow-normalize"
         },
         {
-          "description": "core:path:deny-dirname -> Denies the dirname command without any pre-configured scope.",
+          "description": "Enables the resolve command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:deny-dirname"]
+          "const": "core:path:allow-resolve"
         },
         {
-          "description": "core:path:deny-extname -> Denies the extname command without any pre-configured scope.",
+          "description": "Enables the resolve_directory command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:deny-extname"]
+          "const": "core:path:allow-resolve-directory"
         },
         {
-          "description": "core:path:deny-is-absolute -> Denies the is_absolute command without any pre-configured scope.",
+          "description": "Denies the basename command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:deny-is-absolute"]
+          "const": "core:path:deny-basename"
         },
         {
-          "description": "core:path:deny-join -> Denies the join command without any pre-configured scope.",
+          "description": "Denies the dirname command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:deny-join"]
+          "const": "core:path:deny-dirname"
         },
         {
-          "description": "core:path:deny-normalize -> Denies the normalize command without any pre-configured scope.",
+          "description": "Denies the extname command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:deny-normalize"]
+          "const": "core:path:deny-extname"
         },
         {
-          "description": "core:path:deny-resolve -> Denies the resolve command without any pre-configured scope.",
+          "description": "Denies the is_absolute command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:deny-resolve"]
+          "const": "core:path:deny-is-absolute"
         },
         {
-          "description": "core:path:deny-resolve-directory -> Denies the resolve_directory command without any pre-configured scope.",
+          "description": "Denies the join command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:path:deny-resolve-directory"]
+          "const": "core:path:deny-join"
         },
         {
-          "description": "core:resources:default -> Default permissions for the plugin.",
+          "description": "Denies the normalize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:resources:default"]
+          "const": "core:path:deny-normalize"
         },
         {
-          "description": "core:resources:allow-close -> Enables the close command without any pre-configured scope.",
+          "description": "Denies the resolve command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:resources:allow-close"]
+          "const": "core:path:deny-resolve"
         },
         {
-          "description": "core:resources:deny-close -> Denies the close command without any pre-configured scope.",
+          "description": "Denies the resolve_directory command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:resources:deny-close"]
+          "const": "core:path:deny-resolve-directory"
         },
         {
-          "description": "core:tray:default -> Default permissions for the plugin.",
+          "description": "Default permissions for the plugin.",
           "type": "string",
-          "enum": ["core:tray:default"]
+          "const": "core:resources:default"
         },
         {
-          "description": "core:tray:allow-get-by-id -> Enables the get_by_id command without any pre-configured scope.",
+          "description": "Enables the close command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:allow-get-by-id"]
+          "const": "core:resources:allow-close"
         },
         {
-          "description": "core:tray:allow-new -> Enables the new command without any pre-configured scope.",
+          "description": "Denies the close command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:allow-new"]
+          "const": "core:resources:deny-close"
         },
         {
-          "description": "core:tray:allow-remove-by-id -> Enables the remove_by_id command without any pre-configured scope.",
+          "description": "Default permissions for the plugin.",
           "type": "string",
-          "enum": ["core:tray:allow-remove-by-id"]
+          "const": "core:tray:default"
         },
         {
-          "description": "core:tray:allow-set-icon -> Enables the set_icon command without any pre-configured scope.",
+          "description": "Enables the get_by_id command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:allow-set-icon"]
+          "const": "core:tray:allow-get-by-id"
         },
         {
-          "description": "core:tray:allow-set-icon-as-template -> Enables the set_icon_as_template command without any pre-configured scope.",
+          "description": "Enables the new command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:allow-set-icon-as-template"]
+          "const": "core:tray:allow-new"
         },
         {
-          "description": "core:tray:allow-set-menu -> Enables the set_menu command without any pre-configured scope.",
+          "description": "Enables the remove_by_id command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:allow-set-menu"]
+          "const": "core:tray:allow-remove-by-id"
         },
         {
-          "description": "core:tray:allow-set-show-menu-on-left-click -> Enables the set_show_menu_on_left_click command without any pre-configured scope.",
+          "description": "Enables the set_icon command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:allow-set-show-menu-on-left-click"]
+          "const": "core:tray:allow-set-icon"
         },
         {
-          "description": "core:tray:allow-set-temp-dir-path -> Enables the set_temp_dir_path command without any pre-configured scope.",
+          "description": "Enables the set_icon_as_template command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:allow-set-temp-dir-path"]
+          "const": "core:tray:allow-set-icon-as-template"
         },
         {
-          "description": "core:tray:allow-set-title -> Enables the set_title command without any pre-configured scope.",
+          "description": "Enables the set_menu command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:allow-set-title"]
+          "const": "core:tray:allow-set-menu"
         },
         {
-          "description": "core:tray:allow-set-tooltip -> Enables the set_tooltip command without any pre-configured scope.",
+          "description": "Enables the set_show_menu_on_left_click command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:allow-set-tooltip"]
+          "const": "core:tray:allow-set-show-menu-on-left-click"
         },
         {
-          "description": "core:tray:allow-set-visible -> Enables the set_visible command without any pre-configured scope.",
+          "description": "Enables the set_temp_dir_path command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:allow-set-visible"]
+          "const": "core:tray:allow-set-temp-dir-path"
         },
         {
-          "description": "core:tray:deny-get-by-id -> Denies the get_by_id command without any pre-configured scope.",
+          "description": "Enables the set_title command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:deny-get-by-id"]
+          "const": "core:tray:allow-set-title"
         },
         {
-          "description": "core:tray:deny-new -> Denies the new command without any pre-configured scope.",
+          "description": "Enables the set_tooltip command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:deny-new"]
+          "const": "core:tray:allow-set-tooltip"
         },
         {
-          "description": "core:tray:deny-remove-by-id -> Denies the remove_by_id command without any pre-configured scope.",
+          "description": "Enables the set_visible command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:deny-remove-by-id"]
+          "const": "core:tray:allow-set-visible"
         },
         {
-          "description": "core:tray:deny-set-icon -> Denies the set_icon command without any pre-configured scope.",
+          "description": "Denies the get_by_id command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:deny-set-icon"]
+          "const": "core:tray:deny-get-by-id"
         },
         {
-          "description": "core:tray:deny-set-icon-as-template -> Denies the set_icon_as_template command without any pre-configured scope.",
+          "description": "Denies the new command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:deny-set-icon-as-template"]
+          "const": "core:tray:deny-new"
         },
         {
-          "description": "core:tray:deny-set-menu -> Denies the set_menu command without any pre-configured scope.",
+          "description": "Denies the remove_by_id command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:deny-set-menu"]
+          "const": "core:tray:deny-remove-by-id"
         },
         {
-          "description": "core:tray:deny-set-show-menu-on-left-click -> Denies the set_show_menu_on_left_click command without any pre-configured scope.",
+          "description": "Denies the set_icon command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:deny-set-show-menu-on-left-click"]
+          "const": "core:tray:deny-set-icon"
         },
         {
-          "description": "core:tray:deny-set-temp-dir-path -> Denies the set_temp_dir_path command without any pre-configured scope.",
+          "description": "Denies the set_icon_as_template command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:deny-set-temp-dir-path"]
+          "const": "core:tray:deny-set-icon-as-template"
         },
         {
-          "description": "core:tray:deny-set-title -> Denies the set_title command without any pre-configured scope.",
+          "description": "Denies the set_menu command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:deny-set-title"]
+          "const": "core:tray:deny-set-menu"
         },
         {
-          "description": "core:tray:deny-set-tooltip -> Denies the set_tooltip command without any pre-configured scope.",
+          "description": "Denies the set_show_menu_on_left_click command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:deny-set-tooltip"]
+          "const": "core:tray:deny-set-show-menu-on-left-click"
         },
         {
-          "description": "core:tray:deny-set-visible -> Denies the set_visible command without any pre-configured scope.",
+          "description": "Denies the set_temp_dir_path command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:tray:deny-set-visible"]
+          "const": "core:tray:deny-set-temp-dir-path"
         },
         {
-          "description": "core:webview:default -> Default permissions for the plugin.",
+          "description": "Denies the set_title command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:default"]
+          "const": "core:tray:deny-set-title"
         },
         {
-          "description": "core:webview:allow-create-webview -> Enables the create_webview command without any pre-configured scope.",
+          "description": "Denies the set_tooltip command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:allow-create-webview"]
+          "const": "core:tray:deny-set-tooltip"
         },
         {
-          "description": "core:webview:allow-create-webview-window -> Enables the create_webview_window command without any pre-configured scope.",
+          "description": "Denies the set_visible command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:allow-create-webview-window"]
+          "const": "core:tray:deny-set-visible"
         },
         {
-          "description": "core:webview:allow-get-all-webviews -> Enables the get_all_webviews command without any pre-configured scope.",
+          "description": "Default permissions for the plugin.",
           "type": "string",
-          "enum": ["core:webview:allow-get-all-webviews"]
+          "const": "core:webview:default"
         },
         {
-          "description": "core:webview:allow-internal-toggle-devtools -> Enables the internal_toggle_devtools command without any pre-configured scope.",
+          "description": "Enables the clear_all_browsing_data command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:allow-internal-toggle-devtools"]
+          "const": "core:webview:allow-clear-all-browsing-data"
         },
         {
-          "description": "core:webview:allow-print -> Enables the print command without any pre-configured scope.",
+          "description": "Enables the create_webview command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:allow-print"]
+          "const": "core:webview:allow-create-webview"
         },
         {
-          "description": "core:webview:allow-reparent -> Enables the reparent command without any pre-configured scope.",
+          "description": "Enables the create_webview_window command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:allow-reparent"]
+          "const": "core:webview:allow-create-webview-window"
         },
         {
-          "description": "core:webview:allow-set-webview-focus -> Enables the set_webview_focus command without any pre-configured scope.",
+          "description": "Enables the get_all_webviews command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:allow-set-webview-focus"]
+          "const": "core:webview:allow-get-all-webviews"
         },
         {
-          "description": "core:webview:allow-set-webview-position -> Enables the set_webview_position command without any pre-configured scope.",
+          "description": "Enables the internal_toggle_devtools command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:allow-set-webview-position"]
+          "const": "core:webview:allow-internal-toggle-devtools"
         },
         {
-          "description": "core:webview:allow-set-webview-size -> Enables the set_webview_size command without any pre-configured scope.",
+          "description": "Enables the print command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:allow-set-webview-size"]
+          "const": "core:webview:allow-print"
         },
         {
-          "description": "core:webview:allow-set-webview-zoom -> Enables the set_webview_zoom command without any pre-configured scope.",
+          "description": "Enables the reparent command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:allow-set-webview-zoom"]
+          "const": "core:webview:allow-reparent"
         },
         {
-          "description": "core:webview:allow-webview-close -> Enables the webview_close command without any pre-configured scope.",
+          "description": "Enables the set_webview_background_color command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:allow-webview-close"]
+          "const": "core:webview:allow-set-webview-background-color"
         },
         {
-          "description": "core:webview:allow-webview-position -> Enables the webview_position command without any pre-configured scope.",
+          "description": "Enables the set_webview_focus command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:allow-webview-position"]
+          "const": "core:webview:allow-set-webview-focus"
         },
         {
-          "description": "core:webview:allow-webview-size -> Enables the webview_size command without any pre-configured scope.",
+          "description": "Enables the set_webview_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:allow-webview-size"]
+          "const": "core:webview:allow-set-webview-position"
         },
         {
-          "description": "core:webview:deny-create-webview -> Denies the create_webview command without any pre-configured scope.",
+          "description": "Enables the set_webview_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:deny-create-webview"]
+          "const": "core:webview:allow-set-webview-size"
         },
         {
-          "description": "core:webview:deny-create-webview-window -> Denies the create_webview_window command without any pre-configured scope.",
+          "description": "Enables the set_webview_zoom command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:deny-create-webview-window"]
+          "const": "core:webview:allow-set-webview-zoom"
         },
         {
-          "description": "core:webview:deny-get-all-webviews -> Denies the get_all_webviews command without any pre-configured scope.",
+          "description": "Enables the webview_close command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:deny-get-all-webviews"]
+          "const": "core:webview:allow-webview-close"
         },
         {
-          "description": "core:webview:deny-internal-toggle-devtools -> Denies the internal_toggle_devtools command without any pre-configured scope.",
+          "description": "Enables the webview_hide command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:deny-internal-toggle-devtools"]
+          "const": "core:webview:allow-webview-hide"
         },
         {
-          "description": "core:webview:deny-print -> Denies the print command without any pre-configured scope.",
+          "description": "Enables the webview_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:deny-print"]
+          "const": "core:webview:allow-webview-position"
         },
         {
-          "description": "core:webview:deny-reparent -> Denies the reparent command without any pre-configured scope.",
+          "description": "Enables the webview_show command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:deny-reparent"]
+          "const": "core:webview:allow-webview-show"
         },
         {
-          "description": "core:webview:deny-set-webview-focus -> Denies the set_webview_focus command without any pre-configured scope.",
+          "description": "Enables the webview_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:deny-set-webview-focus"]
+          "const": "core:webview:allow-webview-size"
         },
         {
-          "description": "core:webview:deny-set-webview-position -> Denies the set_webview_position command without any pre-configured scope.",
+          "description": "Denies the clear_all_browsing_data command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:deny-set-webview-position"]
+          "const": "core:webview:deny-clear-all-browsing-data"
         },
         {
-          "description": "core:webview:deny-set-webview-size -> Denies the set_webview_size command without any pre-configured scope.",
+          "description": "Denies the create_webview command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:deny-set-webview-size"]
+          "const": "core:webview:deny-create-webview"
         },
         {
-          "description": "core:webview:deny-set-webview-zoom -> Denies the set_webview_zoom command without any pre-configured scope.",
+          "description": "Denies the create_webview_window command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:deny-set-webview-zoom"]
+          "const": "core:webview:deny-create-webview-window"
         },
         {
-          "description": "core:webview:deny-webview-close -> Denies the webview_close command without any pre-configured scope.",
+          "description": "Denies the get_all_webviews command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:deny-webview-close"]
+          "const": "core:webview:deny-get-all-webviews"
         },
         {
-          "description": "core:webview:deny-webview-position -> Denies the webview_position command without any pre-configured scope.",
+          "description": "Denies the internal_toggle_devtools command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:deny-webview-position"]
+          "const": "core:webview:deny-internal-toggle-devtools"
         },
         {
-          "description": "core:webview:deny-webview-size -> Denies the webview_size command without any pre-configured scope.",
+          "description": "Denies the print command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:webview:deny-webview-size"]
+          "const": "core:webview:deny-print"
         },
         {
-          "description": "core:window:default -> Default permissions for the plugin.",
+          "description": "Denies the reparent command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:default"]
+          "const": "core:webview:deny-reparent"
         },
         {
-          "description": "core:window:allow-available-monitors -> Enables the available_monitors command without any pre-configured scope.",
+          "description": "Denies the set_webview_background_color command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-available-monitors"]
+          "const": "core:webview:deny-set-webview-background-color"
         },
         {
-          "description": "core:window:allow-center -> Enables the center command without any pre-configured scope.",
+          "description": "Denies the set_webview_focus command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-center"]
+          "const": "core:webview:deny-set-webview-focus"
         },
         {
-          "description": "core:window:allow-close -> Enables the close command without any pre-configured scope.",
+          "description": "Denies the set_webview_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-close"]
+          "const": "core:webview:deny-set-webview-position"
         },
         {
-          "description": "core:window:allow-create -> Enables the create command without any pre-configured scope.",
+          "description": "Denies the set_webview_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-create"]
+          "const": "core:webview:deny-set-webview-size"
         },
         {
-          "description": "core:window:allow-current-monitor -> Enables the current_monitor command without any pre-configured scope.",
+          "description": "Denies the set_webview_zoom command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-current-monitor"]
+          "const": "core:webview:deny-set-webview-zoom"
         },
         {
-          "description": "core:window:allow-cursor-position -> Enables the cursor_position command without any pre-configured scope.",
+          "description": "Denies the webview_close command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-cursor-position"]
+          "const": "core:webview:deny-webview-close"
         },
         {
-          "description": "core:window:allow-destroy -> Enables the destroy command without any pre-configured scope.",
+          "description": "Denies the webview_hide command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-destroy"]
+          "const": "core:webview:deny-webview-hide"
         },
         {
-          "description": "core:window:allow-get-all-windows -> Enables the get_all_windows command without any pre-configured scope.",
+          "description": "Denies the webview_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-get-all-windows"]
+          "const": "core:webview:deny-webview-position"
         },
         {
-          "description": "core:window:allow-hide -> Enables the hide command without any pre-configured scope.",
+          "description": "Denies the webview_show command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-hide"]
+          "const": "core:webview:deny-webview-show"
         },
         {
-          "description": "core:window:allow-inner-position -> Enables the inner_position command without any pre-configured scope.",
+          "description": "Denies the webview_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-inner-position"]
+          "const": "core:webview:deny-webview-size"
         },
         {
-          "description": "core:window:allow-inner-size -> Enables the inner_size command without any pre-configured scope.",
+          "description": "Default permissions for the plugin.",
           "type": "string",
-          "enum": ["core:window:allow-inner-size"]
+          "const": "core:window:default"
         },
         {
-          "description": "core:window:allow-internal-toggle-maximize -> Enables the internal_toggle_maximize command without any pre-configured scope.",
+          "description": "Enables the available_monitors command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-internal-toggle-maximize"]
+          "const": "core:window:allow-available-monitors"
         },
         {
-          "description": "core:window:allow-is-closable -> Enables the is_closable command without any pre-configured scope.",
+          "description": "Enables the center command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-is-closable"]
+          "const": "core:window:allow-center"
         },
         {
-          "description": "core:window:allow-is-decorated -> Enables the is_decorated command without any pre-configured scope.",
+          "description": "Enables the close command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-is-decorated"]
+          "const": "core:window:allow-close"
         },
         {
-          "description": "core:window:allow-is-focused -> Enables the is_focused command without any pre-configured scope.",
+          "description": "Enables the create command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-is-focused"]
+          "const": "core:window:allow-create"
         },
         {
-          "description": "core:window:allow-is-fullscreen -> Enables the is_fullscreen command without any pre-configured scope.",
+          "description": "Enables the current_monitor command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-is-fullscreen"]
+          "const": "core:window:allow-current-monitor"
         },
         {
-          "description": "core:window:allow-is-maximizable -> Enables the is_maximizable command without any pre-configured scope.",
+          "description": "Enables the cursor_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-is-maximizable"]
+          "const": "core:window:allow-cursor-position"
         },
         {
-          "description": "core:window:allow-is-maximized -> Enables the is_maximized command without any pre-configured scope.",
+          "description": "Enables the destroy command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-is-maximized"]
+          "const": "core:window:allow-destroy"
         },
         {
-          "description": "core:window:allow-is-minimizable -> Enables the is_minimizable command without any pre-configured scope.",
+          "description": "Enables the get_all_windows command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-is-minimizable"]
+          "const": "core:window:allow-get-all-windows"
         },
         {
-          "description": "core:window:allow-is-minimized -> Enables the is_minimized command without any pre-configured scope.",
+          "description": "Enables the hide command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-is-minimized"]
+          "const": "core:window:allow-hide"
         },
         {
-          "description": "core:window:allow-is-resizable -> Enables the is_resizable command without any pre-configured scope.",
+          "description": "Enables the inner_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-is-resizable"]
+          "const": "core:window:allow-inner-position"
         },
         {
-          "description": "core:window:allow-is-visible -> Enables the is_visible command without any pre-configured scope.",
+          "description": "Enables the inner_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-is-visible"]
+          "const": "core:window:allow-inner-size"
         },
         {
-          "description": "core:window:allow-maximize -> Enables the maximize command without any pre-configured scope.",
+          "description": "Enables the internal_toggle_maximize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-maximize"]
+          "const": "core:window:allow-internal-toggle-maximize"
         },
         {
-          "description": "core:window:allow-minimize -> Enables the minimize command without any pre-configured scope.",
+          "description": "Enables the is_closable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-minimize"]
+          "const": "core:window:allow-is-closable"
         },
         {
-          "description": "core:window:allow-monitor-from-point -> Enables the monitor_from_point command without any pre-configured scope.",
+          "description": "Enables the is_decorated command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-monitor-from-point"]
+          "const": "core:window:allow-is-decorated"
         },
         {
-          "description": "core:window:allow-outer-position -> Enables the outer_position command without any pre-configured scope.",
+          "description": "Enables the is_enabled command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-outer-position"]
+          "const": "core:window:allow-is-enabled"
         },
         {
-          "description": "core:window:allow-outer-size -> Enables the outer_size command without any pre-configured scope.",
+          "description": "Enables the is_focused command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-outer-size"]
+          "const": "core:window:allow-is-focused"
         },
         {
-          "description": "core:window:allow-primary-monitor -> Enables the primary_monitor command without any pre-configured scope.",
+          "description": "Enables the is_fullscreen command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-primary-monitor"]
+          "const": "core:window:allow-is-fullscreen"
         },
         {
-          "description": "core:window:allow-request-user-attention -> Enables the request_user_attention command without any pre-configured scope.",
+          "description": "Enables the is_maximizable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-request-user-attention"]
+          "const": "core:window:allow-is-maximizable"
         },
         {
-          "description": "core:window:allow-scale-factor -> Enables the scale_factor command without any pre-configured scope.",
+          "description": "Enables the is_maximized command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-scale-factor"]
+          "const": "core:window:allow-is-maximized"
         },
         {
-          "description": "core:window:allow-set-always-on-bottom -> Enables the set_always_on_bottom command without any pre-configured scope.",
+          "description": "Enables the is_minimizable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-always-on-bottom"]
+          "const": "core:window:allow-is-minimizable"
         },
         {
-          "description": "core:window:allow-set-always-on-top -> Enables the set_always_on_top command without any pre-configured scope.",
+          "description": "Enables the is_minimized command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-always-on-top"]
+          "const": "core:window:allow-is-minimized"
         },
         {
-          "description": "core:window:allow-set-closable -> Enables the set_closable command without any pre-configured scope.",
+          "description": "Enables the is_resizable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-closable"]
+          "const": "core:window:allow-is-resizable"
         },
         {
-          "description": "core:window:allow-set-content-protected -> Enables the set_content_protected command without any pre-configured scope.",
+          "description": "Enables the is_visible command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-content-protected"]
+          "const": "core:window:allow-is-visible"
         },
         {
-          "description": "core:window:allow-set-cursor-grab -> Enables the set_cursor_grab command without any pre-configured scope.",
+          "description": "Enables the maximize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-cursor-grab"]
+          "const": "core:window:allow-maximize"
         },
         {
-          "description": "core:window:allow-set-cursor-icon -> Enables the set_cursor_icon command without any pre-configured scope.",
+          "description": "Enables the minimize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-cursor-icon"]
+          "const": "core:window:allow-minimize"
         },
         {
-          "description": "core:window:allow-set-cursor-position -> Enables the set_cursor_position command without any pre-configured scope.",
+          "description": "Enables the monitor_from_point command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-cursor-position"]
+          "const": "core:window:allow-monitor-from-point"
         },
         {
-          "description": "core:window:allow-set-cursor-visible -> Enables the set_cursor_visible command without any pre-configured scope.",
+          "description": "Enables the outer_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-cursor-visible"]
+          "const": "core:window:allow-outer-position"
         },
         {
-          "description": "core:window:allow-set-decorations -> Enables the set_decorations command without any pre-configured scope.",
+          "description": "Enables the outer_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-decorations"]
+          "const": "core:window:allow-outer-size"
         },
         {
-          "description": "core:window:allow-set-effects -> Enables the set_effects command without any pre-configured scope.",
+          "description": "Enables the primary_monitor command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-effects"]
+          "const": "core:window:allow-primary-monitor"
         },
         {
-          "description": "core:window:allow-set-focus -> Enables the set_focus command without any pre-configured scope.",
+          "description": "Enables the request_user_attention command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-focus"]
+          "const": "core:window:allow-request-user-attention"
         },
         {
-          "description": "core:window:allow-set-fullscreen -> Enables the set_fullscreen command without any pre-configured scope.",
+          "description": "Enables the scale_factor command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-fullscreen"]
+          "const": "core:window:allow-scale-factor"
         },
         {
-          "description": "core:window:allow-set-icon -> Enables the set_icon command without any pre-configured scope.",
+          "description": "Enables the set_always_on_bottom command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-icon"]
+          "const": "core:window:allow-set-always-on-bottom"
         },
         {
-          "description": "core:window:allow-set-ignore-cursor-events -> Enables the set_ignore_cursor_events command without any pre-configured scope.",
+          "description": "Enables the set_always_on_top command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-ignore-cursor-events"]
+          "const": "core:window:allow-set-always-on-top"
         },
         {
-          "description": "core:window:allow-set-max-size -> Enables the set_max_size command without any pre-configured scope.",
+          "description": "Enables the set_background_color command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-max-size"]
+          "const": "core:window:allow-set-background-color"
         },
         {
-          "description": "core:window:allow-set-maximizable -> Enables the set_maximizable command without any pre-configured scope.",
+          "description": "Enables the set_badge_count command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-maximizable"]
+          "const": "core:window:allow-set-badge-count"
         },
         {
-          "description": "core:window:allow-set-min-size -> Enables the set_min_size command without any pre-configured scope.",
+          "description": "Enables the set_badge_label command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-min-size"]
+          "const": "core:window:allow-set-badge-label"
         },
         {
-          "description": "core:window:allow-set-minimizable -> Enables the set_minimizable command without any pre-configured scope.",
+          "description": "Enables the set_closable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-minimizable"]
+          "const": "core:window:allow-set-closable"
         },
         {
-          "description": "core:window:allow-set-position -> Enables the set_position command without any pre-configured scope.",
+          "description": "Enables the set_content_protected command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-position"]
+          "const": "core:window:allow-set-content-protected"
         },
         {
-          "description": "core:window:allow-set-progress-bar -> Enables the set_progress_bar command without any pre-configured scope.",
+          "description": "Enables the set_cursor_grab command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-progress-bar"]
+          "const": "core:window:allow-set-cursor-grab"
         },
         {
-          "description": "core:window:allow-set-resizable -> Enables the set_resizable command without any pre-configured scope.",
+          "description": "Enables the set_cursor_icon command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-resizable"]
+          "const": "core:window:allow-set-cursor-icon"
         },
         {
-          "description": "core:window:allow-set-shadow -> Enables the set_shadow command without any pre-configured scope.",
+          "description": "Enables the set_cursor_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-shadow"]
+          "const": "core:window:allow-set-cursor-position"
         },
         {
-          "description": "core:window:allow-set-size -> Enables the set_size command without any pre-configured scope.",
+          "description": "Enables the set_cursor_visible command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-size"]
+          "const": "core:window:allow-set-cursor-visible"
         },
         {
-          "description": "core:window:allow-set-size-constraints -> Enables the set_size_constraints command without any pre-configured scope.",
+          "description": "Enables the set_decorations command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-size-constraints"]
+          "const": "core:window:allow-set-decorations"
         },
         {
-          "description": "core:window:allow-set-skip-taskbar -> Enables the set_skip_taskbar command without any pre-configured scope.",
+          "description": "Enables the set_effects command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-skip-taskbar"]
+          "const": "core:window:allow-set-effects"
         },
         {
-          "description": "core:window:allow-set-title -> Enables the set_title command without any pre-configured scope.",
+          "description": "Enables the set_enabled command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-title"]
+          "const": "core:window:allow-set-enabled"
         },
         {
-          "description": "core:window:allow-set-title-bar-style -> Enables the set_title_bar_style command without any pre-configured scope.",
+          "description": "Enables the set_focus command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-title-bar-style"]
+          "const": "core:window:allow-set-focus"
         },
         {
-          "description": "core:window:allow-set-visible-on-all-workspaces -> Enables the set_visible_on_all_workspaces command without any pre-configured scope.",
+          "description": "Enables the set_fullscreen command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-set-visible-on-all-workspaces"]
+          "const": "core:window:allow-set-fullscreen"
         },
         {
-          "description": "core:window:allow-show -> Enables the show command without any pre-configured scope.",
+          "description": "Enables the set_icon command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-show"]
+          "const": "core:window:allow-set-icon"
         },
         {
-          "description": "core:window:allow-start-dragging -> Enables the start_dragging command without any pre-configured scope.",
+          "description": "Enables the set_ignore_cursor_events command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-start-dragging"]
+          "const": "core:window:allow-set-ignore-cursor-events"
         },
         {
-          "description": "core:window:allow-start-resize-dragging -> Enables the start_resize_dragging command without any pre-configured scope.",
+          "description": "Enables the set_max_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-start-resize-dragging"]
+          "const": "core:window:allow-set-max-size"
         },
         {
-          "description": "core:window:allow-theme -> Enables the theme command without any pre-configured scope.",
+          "description": "Enables the set_maximizable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-theme"]
+          "const": "core:window:allow-set-maximizable"
         },
         {
-          "description": "core:window:allow-title -> Enables the title command without any pre-configured scope.",
+          "description": "Enables the set_min_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-title"]
+          "const": "core:window:allow-set-min-size"
         },
         {
-          "description": "core:window:allow-toggle-maximize -> Enables the toggle_maximize command without any pre-configured scope.",
+          "description": "Enables the set_minimizable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-toggle-maximize"]
+          "const": "core:window:allow-set-minimizable"
         },
         {
-          "description": "core:window:allow-unmaximize -> Enables the unmaximize command without any pre-configured scope.",
+          "description": "Enables the set_overlay_icon command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-unmaximize"]
+          "const": "core:window:allow-set-overlay-icon"
         },
         {
-          "description": "core:window:allow-unminimize -> Enables the unminimize command without any pre-configured scope.",
+          "description": "Enables the set_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:allow-unminimize"]
+          "const": "core:window:allow-set-position"
         },
         {
-          "description": "core:window:deny-available-monitors -> Denies the available_monitors command without any pre-configured scope.",
+          "description": "Enables the set_progress_bar command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-available-monitors"]
+          "const": "core:window:allow-set-progress-bar"
         },
         {
-          "description": "core:window:deny-center -> Denies the center command without any pre-configured scope.",
+          "description": "Enables the set_resizable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-center"]
+          "const": "core:window:allow-set-resizable"
         },
         {
-          "description": "core:window:deny-close -> Denies the close command without any pre-configured scope.",
+          "description": "Enables the set_shadow command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-close"]
+          "const": "core:window:allow-set-shadow"
         },
         {
-          "description": "core:window:deny-create -> Denies the create command without any pre-configured scope.",
+          "description": "Enables the set_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-create"]
+          "const": "core:window:allow-set-size"
         },
         {
-          "description": "core:window:deny-current-monitor -> Denies the current_monitor command without any pre-configured scope.",
+          "description": "Enables the set_size_constraints command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-current-monitor"]
+          "const": "core:window:allow-set-size-constraints"
         },
         {
-          "description": "core:window:deny-cursor-position -> Denies the cursor_position command without any pre-configured scope.",
+          "description": "Enables the set_skip_taskbar command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-cursor-position"]
+          "const": "core:window:allow-set-skip-taskbar"
         },
         {
-          "description": "core:window:deny-destroy -> Denies the destroy command without any pre-configured scope.",
+          "description": "Enables the set_theme command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-destroy"]
+          "const": "core:window:allow-set-theme"
         },
         {
-          "description": "core:window:deny-get-all-windows -> Denies the get_all_windows command without any pre-configured scope.",
+          "description": "Enables the set_title command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-get-all-windows"]
+          "const": "core:window:allow-set-title"
         },
         {
-          "description": "core:window:deny-hide -> Denies the hide command without any pre-configured scope.",
+          "description": "Enables the set_title_bar_style command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-hide"]
+          "const": "core:window:allow-set-title-bar-style"
         },
         {
-          "description": "core:window:deny-inner-position -> Denies the inner_position command without any pre-configured scope.",
+          "description": "Enables the set_visible_on_all_workspaces command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-inner-position"]
+          "const": "core:window:allow-set-visible-on-all-workspaces"
         },
         {
-          "description": "core:window:deny-inner-size -> Denies the inner_size command without any pre-configured scope.",
+          "description": "Enables the show command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-inner-size"]
+          "const": "core:window:allow-show"
         },
         {
-          "description": "core:window:deny-internal-toggle-maximize -> Denies the internal_toggle_maximize command without any pre-configured scope.",
+          "description": "Enables the start_dragging command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-internal-toggle-maximize"]
+          "const": "core:window:allow-start-dragging"
         },
         {
-          "description": "core:window:deny-is-closable -> Denies the is_closable command without any pre-configured scope.",
+          "description": "Enables the start_resize_dragging command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-is-closable"]
+          "const": "core:window:allow-start-resize-dragging"
         },
         {
-          "description": "core:window:deny-is-decorated -> Denies the is_decorated command without any pre-configured scope.",
+          "description": "Enables the theme command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-is-decorated"]
+          "const": "core:window:allow-theme"
         },
         {
-          "description": "core:window:deny-is-focused -> Denies the is_focused command without any pre-configured scope.",
+          "description": "Enables the title command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-is-focused"]
+          "const": "core:window:allow-title"
         },
         {
-          "description": "core:window:deny-is-fullscreen -> Denies the is_fullscreen command without any pre-configured scope.",
+          "description": "Enables the toggle_maximize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-is-fullscreen"]
+          "const": "core:window:allow-toggle-maximize"
         },
         {
-          "description": "core:window:deny-is-maximizable -> Denies the is_maximizable command without any pre-configured scope.",
+          "description": "Enables the unmaximize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-is-maximizable"]
+          "const": "core:window:allow-unmaximize"
         },
         {
-          "description": "core:window:deny-is-maximized -> Denies the is_maximized command without any pre-configured scope.",
+          "description": "Enables the unminimize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-is-maximized"]
+          "const": "core:window:allow-unminimize"
         },
         {
-          "description": "core:window:deny-is-minimizable -> Denies the is_minimizable command without any pre-configured scope.",
+          "description": "Denies the available_monitors command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-is-minimizable"]
+          "const": "core:window:deny-available-monitors"
         },
         {
-          "description": "core:window:deny-is-minimized -> Denies the is_minimized command without any pre-configured scope.",
+          "description": "Denies the center command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-is-minimized"]
+          "const": "core:window:deny-center"
         },
         {
-          "description": "core:window:deny-is-resizable -> Denies the is_resizable command without any pre-configured scope.",
+          "description": "Denies the close command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-is-resizable"]
+          "const": "core:window:deny-close"
         },
         {
-          "description": "core:window:deny-is-visible -> Denies the is_visible command without any pre-configured scope.",
+          "description": "Denies the create command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-is-visible"]
+          "const": "core:window:deny-create"
         },
         {
-          "description": "core:window:deny-maximize -> Denies the maximize command without any pre-configured scope.",
+          "description": "Denies the current_monitor command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-maximize"]
+          "const": "core:window:deny-current-monitor"
         },
         {
-          "description": "core:window:deny-minimize -> Denies the minimize command without any pre-configured scope.",
+          "description": "Denies the cursor_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-minimize"]
+          "const": "core:window:deny-cursor-position"
         },
         {
-          "description": "core:window:deny-monitor-from-point -> Denies the monitor_from_point command without any pre-configured scope.",
+          "description": "Denies the destroy command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-monitor-from-point"]
+          "const": "core:window:deny-destroy"
         },
         {
-          "description": "core:window:deny-outer-position -> Denies the outer_position command without any pre-configured scope.",
+          "description": "Denies the get_all_windows command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-outer-position"]
+          "const": "core:window:deny-get-all-windows"
         },
         {
-          "description": "core:window:deny-outer-size -> Denies the outer_size command without any pre-configured scope.",
+          "description": "Denies the hide command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-outer-size"]
+          "const": "core:window:deny-hide"
         },
         {
-          "description": "core:window:deny-primary-monitor -> Denies the primary_monitor command without any pre-configured scope.",
+          "description": "Denies the inner_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-primary-monitor"]
+          "const": "core:window:deny-inner-position"
         },
         {
-          "description": "core:window:deny-request-user-attention -> Denies the request_user_attention command without any pre-configured scope.",
+          "description": "Denies the inner_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-request-user-attention"]
+          "const": "core:window:deny-inner-size"
         },
         {
-          "description": "core:window:deny-scale-factor -> Denies the scale_factor command without any pre-configured scope.",
+          "description": "Denies the internal_toggle_maximize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-scale-factor"]
+          "const": "core:window:deny-internal-toggle-maximize"
         },
         {
-          "description": "core:window:deny-set-always-on-bottom -> Denies the set_always_on_bottom command without any pre-configured scope.",
+          "description": "Denies the is_closable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-always-on-bottom"]
+          "const": "core:window:deny-is-closable"
         },
         {
-          "description": "core:window:deny-set-always-on-top -> Denies the set_always_on_top command without any pre-configured scope.",
+          "description": "Denies the is_decorated command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-always-on-top"]
+          "const": "core:window:deny-is-decorated"
         },
         {
-          "description": "core:window:deny-set-closable -> Denies the set_closable command without any pre-configured scope.",
+          "description": "Denies the is_enabled command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-closable"]
+          "const": "core:window:deny-is-enabled"
         },
         {
-          "description": "core:window:deny-set-content-protected -> Denies the set_content_protected command without any pre-configured scope.",
+          "description": "Denies the is_focused command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-content-protected"]
+          "const": "core:window:deny-is-focused"
         },
         {
-          "description": "core:window:deny-set-cursor-grab -> Denies the set_cursor_grab command without any pre-configured scope.",
+          "description": "Denies the is_fullscreen command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-cursor-grab"]
+          "const": "core:window:deny-is-fullscreen"
         },
         {
-          "description": "core:window:deny-set-cursor-icon -> Denies the set_cursor_icon command without any pre-configured scope.",
+          "description": "Denies the is_maximizable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-cursor-icon"]
+          "const": "core:window:deny-is-maximizable"
         },
         {
-          "description": "core:window:deny-set-cursor-position -> Denies the set_cursor_position command without any pre-configured scope.",
+          "description": "Denies the is_maximized command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-cursor-position"]
+          "const": "core:window:deny-is-maximized"
         },
         {
-          "description": "core:window:deny-set-cursor-visible -> Denies the set_cursor_visible command without any pre-configured scope.",
+          "description": "Denies the is_minimizable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-cursor-visible"]
+          "const": "core:window:deny-is-minimizable"
         },
         {
-          "description": "core:window:deny-set-decorations -> Denies the set_decorations command without any pre-configured scope.",
+          "description": "Denies the is_minimized command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-decorations"]
+          "const": "core:window:deny-is-minimized"
         },
         {
-          "description": "core:window:deny-set-effects -> Denies the set_effects command without any pre-configured scope.",
+          "description": "Denies the is_resizable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-effects"]
+          "const": "core:window:deny-is-resizable"
         },
         {
-          "description": "core:window:deny-set-focus -> Denies the set_focus command without any pre-configured scope.",
+          "description": "Denies the is_visible command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-focus"]
+          "const": "core:window:deny-is-visible"
         },
         {
-          "description": "core:window:deny-set-fullscreen -> Denies the set_fullscreen command without any pre-configured scope.",
+          "description": "Denies the maximize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-fullscreen"]
+          "const": "core:window:deny-maximize"
         },
         {
-          "description": "core:window:deny-set-icon -> Denies the set_icon command without any pre-configured scope.",
+          "description": "Denies the minimize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-icon"]
+          "const": "core:window:deny-minimize"
         },
         {
-          "description": "core:window:deny-set-ignore-cursor-events -> Denies the set_ignore_cursor_events command without any pre-configured scope.",
+          "description": "Denies the monitor_from_point command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-ignore-cursor-events"]
+          "const": "core:window:deny-monitor-from-point"
         },
         {
-          "description": "core:window:deny-set-max-size -> Denies the set_max_size command without any pre-configured scope.",
+          "description": "Denies the outer_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-max-size"]
+          "const": "core:window:deny-outer-position"
         },
         {
-          "description": "core:window:deny-set-maximizable -> Denies the set_maximizable command without any pre-configured scope.",
+          "description": "Denies the outer_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-maximizable"]
+          "const": "core:window:deny-outer-size"
         },
         {
-          "description": "core:window:deny-set-min-size -> Denies the set_min_size command without any pre-configured scope.",
+          "description": "Denies the primary_monitor command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-min-size"]
+          "const": "core:window:deny-primary-monitor"
         },
         {
-          "description": "core:window:deny-set-minimizable -> Denies the set_minimizable command without any pre-configured scope.",
+          "description": "Denies the request_user_attention command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-minimizable"]
+          "const": "core:window:deny-request-user-attention"
         },
         {
-          "description": "core:window:deny-set-position -> Denies the set_position command without any pre-configured scope.",
+          "description": "Denies the scale_factor command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-position"]
+          "const": "core:window:deny-scale-factor"
         },
         {
-          "description": "core:window:deny-set-progress-bar -> Denies the set_progress_bar command without any pre-configured scope.",
+          "description": "Denies the set_always_on_bottom command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-progress-bar"]
+          "const": "core:window:deny-set-always-on-bottom"
         },
         {
-          "description": "core:window:deny-set-resizable -> Denies the set_resizable command without any pre-configured scope.",
+          "description": "Denies the set_always_on_top command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-resizable"]
+          "const": "core:window:deny-set-always-on-top"
         },
         {
-          "description": "core:window:deny-set-shadow -> Denies the set_shadow command without any pre-configured scope.",
+          "description": "Denies the set_background_color command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-shadow"]
+          "const": "core:window:deny-set-background-color"
         },
         {
-          "description": "core:window:deny-set-size -> Denies the set_size command without any pre-configured scope.",
+          "description": "Denies the set_badge_count command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-size"]
+          "const": "core:window:deny-set-badge-count"
         },
         {
-          "description": "core:window:deny-set-size-constraints -> Denies the set_size_constraints command without any pre-configured scope.",
+          "description": "Denies the set_badge_label command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-size-constraints"]
+          "const": "core:window:deny-set-badge-label"
         },
         {
-          "description": "core:window:deny-set-skip-taskbar -> Denies the set_skip_taskbar command without any pre-configured scope.",
+          "description": "Denies the set_closable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-skip-taskbar"]
+          "const": "core:window:deny-set-closable"
         },
         {
-          "description": "core:window:deny-set-title -> Denies the set_title command without any pre-configured scope.",
+          "description": "Denies the set_content_protected command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-title"]
+          "const": "core:window:deny-set-content-protected"
         },
         {
-          "description": "core:window:deny-set-title-bar-style -> Denies the set_title_bar_style command without any pre-configured scope.",
+          "description": "Denies the set_cursor_grab command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-title-bar-style"]
+          "const": "core:window:deny-set-cursor-grab"
         },
         {
-          "description": "core:window:deny-set-visible-on-all-workspaces -> Denies the set_visible_on_all_workspaces command without any pre-configured scope.",
+          "description": "Denies the set_cursor_icon command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-set-visible-on-all-workspaces"]
+          "const": "core:window:deny-set-cursor-icon"
         },
         {
-          "description": "core:window:deny-show -> Denies the show command without any pre-configured scope.",
+          "description": "Denies the set_cursor_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-show"]
+          "const": "core:window:deny-set-cursor-position"
         },
         {
-          "description": "core:window:deny-start-dragging -> Denies the start_dragging command without any pre-configured scope.",
+          "description": "Denies the set_cursor_visible command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-start-dragging"]
+          "const": "core:window:deny-set-cursor-visible"
         },
         {
-          "description": "core:window:deny-start-resize-dragging -> Denies the start_resize_dragging command without any pre-configured scope.",
+          "description": "Denies the set_decorations command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-start-resize-dragging"]
+          "const": "core:window:deny-set-decorations"
         },
         {
-          "description": "core:window:deny-theme -> Denies the theme command without any pre-configured scope.",
+          "description": "Denies the set_effects command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-theme"]
+          "const": "core:window:deny-set-effects"
         },
         {
-          "description": "core:window:deny-title -> Denies the title command without any pre-configured scope.",
+          "description": "Denies the set_enabled command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-title"]
+          "const": "core:window:deny-set-enabled"
         },
         {
-          "description": "core:window:deny-toggle-maximize -> Denies the toggle_maximize command without any pre-configured scope.",
+          "description": "Denies the set_focus command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-toggle-maximize"]
+          "const": "core:window:deny-set-focus"
         },
         {
-          "description": "core:window:deny-unmaximize -> Denies the unmaximize command without any pre-configured scope.",
+          "description": "Denies the set_fullscreen command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-unmaximize"]
+          "const": "core:window:deny-set-fullscreen"
         },
         {
-          "description": "core:window:deny-unminimize -> Denies the unminimize command without any pre-configured scope.",
+          "description": "Denies the set_icon command without any pre-configured scope.",
           "type": "string",
-          "enum": ["core:window:deny-unminimize"]
+          "const": "core:window:deny-set-icon"
         },
         {
-          "description": "fs:allow-app-meta -> This allows non-recursive read access to metadata of the `$APP` folder, including file listing and statistics.",
+          "description": "Denies the set_ignore_cursor_events command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-app-meta"]
+          "const": "core:window:deny-set-ignore-cursor-events"
         },
         {
-          "description": "fs:allow-app-meta-recursive -> This allows full recursive read access to metadata of the `$APP` folder, including file listing and statistics.",
+          "description": "Denies the set_max_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-app-meta-recursive"]
+          "const": "core:window:deny-set-max-size"
         },
         {
-          "description": "fs:allow-app-read -> This allows non-recursive read access to the `$APP` folder.",
+          "description": "Denies the set_maximizable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-app-read"]
+          "const": "core:window:deny-set-maximizable"
         },
         {
-          "description": "fs:allow-app-read-recursive -> This allows full recursive read access to the complete `$APP` folder, files and subdirectories.",
+          "description": "Denies the set_min_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-app-read-recursive"]
+          "const": "core:window:deny-set-min-size"
         },
         {
-          "description": "fs:allow-app-write -> This allows non-recursive write access to the `$APP` folder.",
+          "description": "Denies the set_minimizable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-app-write"]
+          "const": "core:window:deny-set-minimizable"
         },
         {
-          "description": "fs:allow-app-write-recursive -> This allows full recursive write access to the complete `$APP` folder, files and subdirectories.",
+          "description": "Denies the set_overlay_icon command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-app-write-recursive"]
+          "const": "core:window:deny-set-overlay-icon"
         },
         {
-          "description": "fs:allow-appcache-meta -> This allows non-recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.",
+          "description": "Denies the set_position command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appcache-meta"]
+          "const": "core:window:deny-set-position"
         },
         {
-          "description": "fs:allow-appcache-meta-recursive -> This allows full recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.",
+          "description": "Denies the set_progress_bar command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appcache-meta-recursive"]
+          "const": "core:window:deny-set-progress-bar"
         },
         {
-          "description": "fs:allow-appcache-read -> This allows non-recursive read access to the `$APPCACHE` folder.",
+          "description": "Denies the set_resizable command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appcache-read"]
+          "const": "core:window:deny-set-resizable"
         },
         {
-          "description": "fs:allow-appcache-read-recursive -> This allows full recursive read access to the complete `$APPCACHE` folder, files and subdirectories.",
+          "description": "Denies the set_shadow command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appcache-read-recursive"]
+          "const": "core:window:deny-set-shadow"
         },
         {
-          "description": "fs:allow-appcache-write -> This allows non-recursive write access to the `$APPCACHE` folder.",
+          "description": "Denies the set_size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appcache-write"]
+          "const": "core:window:deny-set-size"
         },
         {
-          "description": "fs:allow-appcache-write-recursive -> This allows full recursive write access to the complete `$APPCACHE` folder, files and subdirectories.",
+          "description": "Denies the set_size_constraints command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appcache-write-recursive"]
+          "const": "core:window:deny-set-size-constraints"
         },
         {
-          "description": "fs:allow-appconfig-meta -> This allows non-recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.",
+          "description": "Denies the set_skip_taskbar command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appconfig-meta"]
+          "const": "core:window:deny-set-skip-taskbar"
         },
         {
-          "description": "fs:allow-appconfig-meta-recursive -> This allows full recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.",
+          "description": "Denies the set_theme command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appconfig-meta-recursive"]
+          "const": "core:window:deny-set-theme"
         },
         {
-          "description": "fs:allow-appconfig-read -> This allows non-recursive read access to the `$APPCONFIG` folder.",
+          "description": "Denies the set_title command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appconfig-read"]
+          "const": "core:window:deny-set-title"
         },
         {
-          "description": "fs:allow-appconfig-read-recursive -> This allows full recursive read access to the complete `$APPCONFIG` folder, files and subdirectories.",
+          "description": "Denies the set_title_bar_style command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appconfig-read-recursive"]
+          "const": "core:window:deny-set-title-bar-style"
         },
         {
-          "description": "fs:allow-appconfig-write -> This allows non-recursive write access to the `$APPCONFIG` folder.",
+          "description": "Denies the set_visible_on_all_workspaces command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appconfig-write"]
+          "const": "core:window:deny-set-visible-on-all-workspaces"
         },
         {
-          "description": "fs:allow-appconfig-write-recursive -> This allows full recursive write access to the complete `$APPCONFIG` folder, files and subdirectories.",
+          "description": "Denies the show command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appconfig-write-recursive"]
+          "const": "core:window:deny-show"
         },
         {
-          "description": "fs:allow-appdata-meta -> This allows non-recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.",
+          "description": "Denies the start_dragging command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appdata-meta"]
+          "const": "core:window:deny-start-dragging"
         },
         {
-          "description": "fs:allow-appdata-meta-recursive -> This allows full recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.",
+          "description": "Denies the start_resize_dragging command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appdata-meta-recursive"]
+          "const": "core:window:deny-start-resize-dragging"
         },
         {
-          "description": "fs:allow-appdata-read -> This allows non-recursive read access to the `$APPDATA` folder.",
+          "description": "Denies the theme command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appdata-read"]
+          "const": "core:window:deny-theme"
         },
         {
-          "description": "fs:allow-appdata-read-recursive -> This allows full recursive read access to the complete `$APPDATA` folder, files and subdirectories.",
+          "description": "Denies the title command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appdata-read-recursive"]
+          "const": "core:window:deny-title"
         },
         {
-          "description": "fs:allow-appdata-write -> This allows non-recursive write access to the `$APPDATA` folder.",
+          "description": "Denies the toggle_maximize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appdata-write"]
+          "const": "core:window:deny-toggle-maximize"
         },
         {
-          "description": "fs:allow-appdata-write-recursive -> This allows full recursive write access to the complete `$APPDATA` folder, files and subdirectories.",
+          "description": "Denies the unmaximize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-appdata-write-recursive"]
+          "const": "core:window:deny-unmaximize"
         },
         {
-          "description": "fs:allow-applocaldata-meta -> This allows non-recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.",
+          "description": "Denies the unminimize command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:allow-applocaldata-meta"]
+          "const": "core:window:deny-unminimize"
         },
         {
-          "description": "fs:allow-applocaldata-meta-recursive -> This allows full recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.",
+          "description": "This set of permissions describes the what kind of\nfile system access the `fs` plugin has enabled or denied by default.\n\n#### Granted Permissions\n\nThis default permission set enables read access to the\napplication specific directories (AppConfig, AppData, AppLocalData, AppCache,\nAppLog) and all files and sub directories created in it.\nThe location of these directories depends on the operating system,\nwhere the application is run.\n\nIn general these directories need to be manually created\nby the application at runtime, before accessing files or folders\nin it is possible.\n\nTherefore, it is also allowed to create all of these folders via\nthe `mkdir` command.\n\n#### Denied Permissions\n\nThis default permission set prevents access to critical components\nof the Tauri application by default.\nOn Windows the webview data folder access is denied.\n\n#### Included permissions within this default permission set:\n",
           "type": "string",
-          "enum": ["fs:allow-applocaldata-meta-recursive"]
+          "const": "fs:default"
         },
         {
-          "description": "fs:allow-applocaldata-read -> This allows non-recursive read access to the `$APPLOCALDATA` folder.",
+          "description": "This allows non-recursive read access to metadata of the application folders, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-applocaldata-read"]
+          "const": "fs:allow-app-meta"
         },
         {
-          "description": "fs:allow-applocaldata-read-recursive -> This allows full recursive read access to the complete `$APPLOCALDATA` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the application folders, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-applocaldata-read-recursive"]
+          "const": "fs:allow-app-meta-recursive"
         },
         {
-          "description": "fs:allow-applocaldata-write -> This allows non-recursive write access to the `$APPLOCALDATA` folder.",
+          "description": "This allows non-recursive read access to the application folders.",
           "type": "string",
-          "enum": ["fs:allow-applocaldata-write"]
+          "const": "fs:allow-app-read"
         },
         {
-          "description": "fs:allow-applocaldata-write-recursive -> This allows full recursive write access to the complete `$APPLOCALDATA` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete application folders, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-applocaldata-write-recursive"]
+          "const": "fs:allow-app-read-recursive"
         },
         {
-          "description": "fs:allow-applog-meta -> This allows non-recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the application folders.",
           "type": "string",
-          "enum": ["fs:allow-applog-meta"]
+          "const": "fs:allow-app-write"
         },
         {
-          "description": "fs:allow-applog-meta-recursive -> This allows full recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete application folders, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-applog-meta-recursive"]
+          "const": "fs:allow-app-write-recursive"
         },
         {
-          "description": "fs:allow-applog-read -> This allows non-recursive read access to the `$APPLOG` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-applog-read"]
+          "const": "fs:allow-appcache-meta"
         },
         {
-          "description": "fs:allow-applog-read-recursive -> This allows full recursive read access to the complete `$APPLOG` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-applog-read-recursive"]
+          "const": "fs:allow-appcache-meta-recursive"
         },
         {
-          "description": "fs:allow-applog-write -> This allows non-recursive write access to the `$APPLOG` folder.",
+          "description": "This allows non-recursive read access to the `$APPCACHE` folder.",
           "type": "string",
-          "enum": ["fs:allow-applog-write"]
+          "const": "fs:allow-appcache-read"
         },
         {
-          "description": "fs:allow-applog-write-recursive -> This allows full recursive write access to the complete `$APPLOG` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$APPCACHE` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-applog-write-recursive"]
+          "const": "fs:allow-appcache-read-recursive"
         },
         {
-          "description": "fs:allow-audio-meta -> This allows non-recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$APPCACHE` folder.",
           "type": "string",
-          "enum": ["fs:allow-audio-meta"]
+          "const": "fs:allow-appcache-write"
         },
         {
-          "description": "fs:allow-audio-meta-recursive -> This allows full recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$APPCACHE` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-audio-meta-recursive"]
+          "const": "fs:allow-appcache-write-recursive"
         },
         {
-          "description": "fs:allow-audio-read -> This allows non-recursive read access to the `$AUDIO` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-audio-read"]
+          "const": "fs:allow-appconfig-meta"
         },
         {
-          "description": "fs:allow-audio-read-recursive -> This allows full recursive read access to the complete `$AUDIO` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-audio-read-recursive"]
+          "const": "fs:allow-appconfig-meta-recursive"
         },
         {
-          "description": "fs:allow-audio-write -> This allows non-recursive write access to the `$AUDIO` folder.",
+          "description": "This allows non-recursive read access to the `$APPCONFIG` folder.",
           "type": "string",
-          "enum": ["fs:allow-audio-write"]
+          "const": "fs:allow-appconfig-read"
         },
         {
-          "description": "fs:allow-audio-write-recursive -> This allows full recursive write access to the complete `$AUDIO` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$APPCONFIG` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-audio-write-recursive"]
+          "const": "fs:allow-appconfig-read-recursive"
         },
         {
-          "description": "fs:allow-cache-meta -> This allows non-recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$APPCONFIG` folder.",
           "type": "string",
-          "enum": ["fs:allow-cache-meta"]
+          "const": "fs:allow-appconfig-write"
         },
         {
-          "description": "fs:allow-cache-meta-recursive -> This allows full recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$APPCONFIG` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-cache-meta-recursive"]
+          "const": "fs:allow-appconfig-write-recursive"
         },
         {
-          "description": "fs:allow-cache-read -> This allows non-recursive read access to the `$CACHE` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-cache-read"]
+          "const": "fs:allow-appdata-meta"
         },
         {
-          "description": "fs:allow-cache-read-recursive -> This allows full recursive read access to the complete `$CACHE` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-cache-read-recursive"]
+          "const": "fs:allow-appdata-meta-recursive"
         },
         {
-          "description": "fs:allow-cache-write -> This allows non-recursive write access to the `$CACHE` folder.",
+          "description": "This allows non-recursive read access to the `$APPDATA` folder.",
           "type": "string",
-          "enum": ["fs:allow-cache-write"]
+          "const": "fs:allow-appdata-read"
         },
         {
-          "description": "fs:allow-cache-write-recursive -> This allows full recursive write access to the complete `$CACHE` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$APPDATA` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-cache-write-recursive"]
+          "const": "fs:allow-appdata-read-recursive"
         },
         {
-          "description": "fs:allow-config-meta -> This allows non-recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$APPDATA` folder.",
           "type": "string",
-          "enum": ["fs:allow-config-meta"]
+          "const": "fs:allow-appdata-write"
         },
         {
-          "description": "fs:allow-config-meta-recursive -> This allows full recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$APPDATA` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-config-meta-recursive"]
+          "const": "fs:allow-appdata-write-recursive"
         },
         {
-          "description": "fs:allow-config-read -> This allows non-recursive read access to the `$CONFIG` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-config-read"]
+          "const": "fs:allow-applocaldata-meta"
         },
         {
-          "description": "fs:allow-config-read-recursive -> This allows full recursive read access to the complete `$CONFIG` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-config-read-recursive"]
+          "const": "fs:allow-applocaldata-meta-recursive"
         },
         {
-          "description": "fs:allow-config-write -> This allows non-recursive write access to the `$CONFIG` folder.",
+          "description": "This allows non-recursive read access to the `$APPLOCALDATA` folder.",
           "type": "string",
-          "enum": ["fs:allow-config-write"]
+          "const": "fs:allow-applocaldata-read"
         },
         {
-          "description": "fs:allow-config-write-recursive -> This allows full recursive write access to the complete `$CONFIG` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$APPLOCALDATA` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-config-write-recursive"]
+          "const": "fs:allow-applocaldata-read-recursive"
         },
         {
-          "description": "fs:allow-data-meta -> This allows non-recursive read access to metadata of the `$DATA` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$APPLOCALDATA` folder.",
           "type": "string",
-          "enum": ["fs:allow-data-meta"]
+          "const": "fs:allow-applocaldata-write"
         },
         {
-          "description": "fs:allow-data-meta-recursive -> This allows full recursive read access to metadata of the `$DATA` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$APPLOCALDATA` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-data-meta-recursive"]
+          "const": "fs:allow-applocaldata-write-recursive"
         },
         {
-          "description": "fs:allow-data-read -> This allows non-recursive read access to the `$DATA` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-data-read"]
+          "const": "fs:allow-applog-meta"
         },
         {
-          "description": "fs:allow-data-read-recursive -> This allows full recursive read access to the complete `$DATA` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-data-read-recursive"]
+          "const": "fs:allow-applog-meta-recursive"
         },
         {
-          "description": "fs:allow-data-write -> This allows non-recursive write access to the `$DATA` folder.",
+          "description": "This allows non-recursive read access to the `$APPLOG` folder.",
           "type": "string",
-          "enum": ["fs:allow-data-write"]
+          "const": "fs:allow-applog-read"
         },
         {
-          "description": "fs:allow-data-write-recursive -> This allows full recursive write access to the complete `$DATA` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$APPLOG` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-data-write-recursive"]
+          "const": "fs:allow-applog-read-recursive"
         },
         {
-          "description": "fs:allow-desktop-meta -> This allows non-recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$APPLOG` folder.",
           "type": "string",
-          "enum": ["fs:allow-desktop-meta"]
+          "const": "fs:allow-applog-write"
         },
         {
-          "description": "fs:allow-desktop-meta-recursive -> This allows full recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$APPLOG` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-desktop-meta-recursive"]
+          "const": "fs:allow-applog-write-recursive"
         },
         {
-          "description": "fs:allow-desktop-read -> This allows non-recursive read access to the `$DESKTOP` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-desktop-read"]
+          "const": "fs:allow-audio-meta"
         },
         {
-          "description": "fs:allow-desktop-read-recursive -> This allows full recursive read access to the complete `$DESKTOP` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-desktop-read-recursive"]
+          "const": "fs:allow-audio-meta-recursive"
         },
         {
-          "description": "fs:allow-desktop-write -> This allows non-recursive write access to the `$DESKTOP` folder.",
+          "description": "This allows non-recursive read access to the `$AUDIO` folder.",
           "type": "string",
-          "enum": ["fs:allow-desktop-write"]
+          "const": "fs:allow-audio-read"
         },
         {
-          "description": "fs:allow-desktop-write-recursive -> This allows full recursive write access to the complete `$DESKTOP` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$AUDIO` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-desktop-write-recursive"]
+          "const": "fs:allow-audio-read-recursive"
         },
         {
-          "description": "fs:allow-document-meta -> This allows non-recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$AUDIO` folder.",
           "type": "string",
-          "enum": ["fs:allow-document-meta"]
+          "const": "fs:allow-audio-write"
         },
         {
-          "description": "fs:allow-document-meta-recursive -> This allows full recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$AUDIO` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-document-meta-recursive"]
+          "const": "fs:allow-audio-write-recursive"
         },
         {
-          "description": "fs:allow-document-read -> This allows non-recursive read access to the `$DOCUMENT` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-document-read"]
+          "const": "fs:allow-cache-meta"
         },
         {
-          "description": "fs:allow-document-read-recursive -> This allows full recursive read access to the complete `$DOCUMENT` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-document-read-recursive"]
+          "const": "fs:allow-cache-meta-recursive"
         },
         {
-          "description": "fs:allow-document-write -> This allows non-recursive write access to the `$DOCUMENT` folder.",
+          "description": "This allows non-recursive read access to the `$CACHE` folder.",
           "type": "string",
-          "enum": ["fs:allow-document-write"]
+          "const": "fs:allow-cache-read"
         },
         {
-          "description": "fs:allow-document-write-recursive -> This allows full recursive write access to the complete `$DOCUMENT` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$CACHE` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-document-write-recursive"]
+          "const": "fs:allow-cache-read-recursive"
         },
         {
-          "description": "fs:allow-download-meta -> This allows non-recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$CACHE` folder.",
           "type": "string",
-          "enum": ["fs:allow-download-meta"]
+          "const": "fs:allow-cache-write"
         },
         {
-          "description": "fs:allow-download-meta-recursive -> This allows full recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$CACHE` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-download-meta-recursive"]
+          "const": "fs:allow-cache-write-recursive"
         },
         {
-          "description": "fs:allow-download-read -> This allows non-recursive read access to the `$DOWNLOAD` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-download-read"]
+          "const": "fs:allow-config-meta"
         },
         {
-          "description": "fs:allow-download-read-recursive -> This allows full recursive read access to the complete `$DOWNLOAD` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-download-read-recursive"]
+          "const": "fs:allow-config-meta-recursive"
         },
         {
-          "description": "fs:allow-download-write -> This allows non-recursive write access to the `$DOWNLOAD` folder.",
+          "description": "This allows non-recursive read access to the `$CONFIG` folder.",
           "type": "string",
-          "enum": ["fs:allow-download-write"]
+          "const": "fs:allow-config-read"
         },
         {
-          "description": "fs:allow-download-write-recursive -> This allows full recursive write access to the complete `$DOWNLOAD` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$CONFIG` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-download-write-recursive"]
+          "const": "fs:allow-config-read-recursive"
         },
         {
-          "description": "fs:allow-exe-meta -> This allows non-recursive read access to metadata of the `$EXE` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$CONFIG` folder.",
           "type": "string",
-          "enum": ["fs:allow-exe-meta"]
+          "const": "fs:allow-config-write"
         },
         {
-          "description": "fs:allow-exe-meta-recursive -> This allows full recursive read access to metadata of the `$EXE` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$CONFIG` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-exe-meta-recursive"]
+          "const": "fs:allow-config-write-recursive"
         },
         {
-          "description": "fs:allow-exe-read -> This allows non-recursive read access to the `$EXE` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$DATA` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-exe-read"]
+          "const": "fs:allow-data-meta"
         },
         {
-          "description": "fs:allow-exe-read-recursive -> This allows full recursive read access to the complete `$EXE` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$DATA` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-exe-read-recursive"]
+          "const": "fs:allow-data-meta-recursive"
         },
         {
-          "description": "fs:allow-exe-write -> This allows non-recursive write access to the `$EXE` folder.",
+          "description": "This allows non-recursive read access to the `$DATA` folder.",
           "type": "string",
-          "enum": ["fs:allow-exe-write"]
+          "const": "fs:allow-data-read"
         },
         {
-          "description": "fs:allow-exe-write-recursive -> This allows full recursive write access to the complete `$EXE` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$DATA` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-exe-write-recursive"]
+          "const": "fs:allow-data-read-recursive"
         },
         {
-          "description": "fs:allow-font-meta -> This allows non-recursive read access to metadata of the `$FONT` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$DATA` folder.",
           "type": "string",
-          "enum": ["fs:allow-font-meta"]
+          "const": "fs:allow-data-write"
         },
         {
-          "description": "fs:allow-font-meta-recursive -> This allows full recursive read access to metadata of the `$FONT` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$DATA` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-font-meta-recursive"]
+          "const": "fs:allow-data-write-recursive"
         },
         {
-          "description": "fs:allow-font-read -> This allows non-recursive read access to the `$FONT` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-font-read"]
+          "const": "fs:allow-desktop-meta"
         },
         {
-          "description": "fs:allow-font-read-recursive -> This allows full recursive read access to the complete `$FONT` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-font-read-recursive"]
+          "const": "fs:allow-desktop-meta-recursive"
         },
         {
-          "description": "fs:allow-font-write -> This allows non-recursive write access to the `$FONT` folder.",
+          "description": "This allows non-recursive read access to the `$DESKTOP` folder.",
           "type": "string",
-          "enum": ["fs:allow-font-write"]
+          "const": "fs:allow-desktop-read"
         },
         {
-          "description": "fs:allow-font-write-recursive -> This allows full recursive write access to the complete `$FONT` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$DESKTOP` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-font-write-recursive"]
+          "const": "fs:allow-desktop-read-recursive"
         },
         {
-          "description": "fs:allow-home-meta -> This allows non-recursive read access to metadata of the `$HOME` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$DESKTOP` folder.",
           "type": "string",
-          "enum": ["fs:allow-home-meta"]
+          "const": "fs:allow-desktop-write"
         },
         {
-          "description": "fs:allow-home-meta-recursive -> This allows full recursive read access to metadata of the `$HOME` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$DESKTOP` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-home-meta-recursive"]
+          "const": "fs:allow-desktop-write-recursive"
         },
         {
-          "description": "fs:allow-home-read -> This allows non-recursive read access to the `$HOME` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-home-read"]
+          "const": "fs:allow-document-meta"
         },
         {
-          "description": "fs:allow-home-read-recursive -> This allows full recursive read access to the complete `$HOME` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-home-read-recursive"]
+          "const": "fs:allow-document-meta-recursive"
         },
         {
-          "description": "fs:allow-home-write -> This allows non-recursive write access to the `$HOME` folder.",
+          "description": "This allows non-recursive read access to the `$DOCUMENT` folder.",
           "type": "string",
-          "enum": ["fs:allow-home-write"]
+          "const": "fs:allow-document-read"
         },
         {
-          "description": "fs:allow-home-write-recursive -> This allows full recursive write access to the complete `$HOME` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$DOCUMENT` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-home-write-recursive"]
+          "const": "fs:allow-document-read-recursive"
         },
         {
-          "description": "fs:allow-localdata-meta -> This allows non-recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$DOCUMENT` folder.",
           "type": "string",
-          "enum": ["fs:allow-localdata-meta"]
+          "const": "fs:allow-document-write"
         },
         {
-          "description": "fs:allow-localdata-meta-recursive -> This allows full recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$DOCUMENT` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-localdata-meta-recursive"]
+          "const": "fs:allow-document-write-recursive"
         },
         {
-          "description": "fs:allow-localdata-read -> This allows non-recursive read access to the `$LOCALDATA` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-localdata-read"]
+          "const": "fs:allow-download-meta"
         },
         {
-          "description": "fs:allow-localdata-read-recursive -> This allows full recursive read access to the complete `$LOCALDATA` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-localdata-read-recursive"]
+          "const": "fs:allow-download-meta-recursive"
         },
         {
-          "description": "fs:allow-localdata-write -> This allows non-recursive write access to the `$LOCALDATA` folder.",
+          "description": "This allows non-recursive read access to the `$DOWNLOAD` folder.",
           "type": "string",
-          "enum": ["fs:allow-localdata-write"]
+          "const": "fs:allow-download-read"
         },
         {
-          "description": "fs:allow-localdata-write-recursive -> This allows full recursive write access to the complete `$LOCALDATA` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$DOWNLOAD` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-localdata-write-recursive"]
+          "const": "fs:allow-download-read-recursive"
         },
         {
-          "description": "fs:allow-log-meta -> This allows non-recursive read access to metadata of the `$LOG` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$DOWNLOAD` folder.",
           "type": "string",
-          "enum": ["fs:allow-log-meta"]
+          "const": "fs:allow-download-write"
         },
         {
-          "description": "fs:allow-log-meta-recursive -> This allows full recursive read access to metadata of the `$LOG` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$DOWNLOAD` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-log-meta-recursive"]
+          "const": "fs:allow-download-write-recursive"
         },
         {
-          "description": "fs:allow-log-read -> This allows non-recursive read access to the `$LOG` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$EXE` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-log-read"]
+          "const": "fs:allow-exe-meta"
         },
         {
-          "description": "fs:allow-log-read-recursive -> This allows full recursive read access to the complete `$LOG` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$EXE` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-log-read-recursive"]
+          "const": "fs:allow-exe-meta-recursive"
         },
         {
-          "description": "fs:allow-log-write -> This allows non-recursive write access to the `$LOG` folder.",
+          "description": "This allows non-recursive read access to the `$EXE` folder.",
           "type": "string",
-          "enum": ["fs:allow-log-write"]
+          "const": "fs:allow-exe-read"
         },
         {
-          "description": "fs:allow-log-write-recursive -> This allows full recursive write access to the complete `$LOG` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$EXE` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-log-write-recursive"]
+          "const": "fs:allow-exe-read-recursive"
         },
         {
-          "description": "fs:allow-picture-meta -> This allows non-recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$EXE` folder.",
           "type": "string",
-          "enum": ["fs:allow-picture-meta"]
+          "const": "fs:allow-exe-write"
         },
         {
-          "description": "fs:allow-picture-meta-recursive -> This allows full recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$EXE` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-picture-meta-recursive"]
+          "const": "fs:allow-exe-write-recursive"
         },
         {
-          "description": "fs:allow-picture-read -> This allows non-recursive read access to the `$PICTURE` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$FONT` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-picture-read"]
+          "const": "fs:allow-font-meta"
         },
         {
-          "description": "fs:allow-picture-read-recursive -> This allows full recursive read access to the complete `$PICTURE` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$FONT` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-picture-read-recursive"]
+          "const": "fs:allow-font-meta-recursive"
         },
         {
-          "description": "fs:allow-picture-write -> This allows non-recursive write access to the `$PICTURE` folder.",
+          "description": "This allows non-recursive read access to the `$FONT` folder.",
           "type": "string",
-          "enum": ["fs:allow-picture-write"]
+          "const": "fs:allow-font-read"
         },
         {
-          "description": "fs:allow-picture-write-recursive -> This allows full recursive write access to the complete `$PICTURE` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$FONT` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-picture-write-recursive"]
+          "const": "fs:allow-font-read-recursive"
         },
         {
-          "description": "fs:allow-public-meta -> This allows non-recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$FONT` folder.",
           "type": "string",
-          "enum": ["fs:allow-public-meta"]
+          "const": "fs:allow-font-write"
         },
         {
-          "description": "fs:allow-public-meta-recursive -> This allows full recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$FONT` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-public-meta-recursive"]
+          "const": "fs:allow-font-write-recursive"
         },
         {
-          "description": "fs:allow-public-read -> This allows non-recursive read access to the `$PUBLIC` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$HOME` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-public-read"]
+          "const": "fs:allow-home-meta"
         },
         {
-          "description": "fs:allow-public-read-recursive -> This allows full recursive read access to the complete `$PUBLIC` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$HOME` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-public-read-recursive"]
+          "const": "fs:allow-home-meta-recursive"
         },
         {
-          "description": "fs:allow-public-write -> This allows non-recursive write access to the `$PUBLIC` folder.",
+          "description": "This allows non-recursive read access to the `$HOME` folder.",
           "type": "string",
-          "enum": ["fs:allow-public-write"]
+          "const": "fs:allow-home-read"
         },
         {
-          "description": "fs:allow-public-write-recursive -> This allows full recursive write access to the complete `$PUBLIC` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$HOME` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-public-write-recursive"]
+          "const": "fs:allow-home-read-recursive"
         },
         {
-          "description": "fs:allow-resource-meta -> This allows non-recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$HOME` folder.",
           "type": "string",
-          "enum": ["fs:allow-resource-meta"]
+          "const": "fs:allow-home-write"
         },
         {
-          "description": "fs:allow-resource-meta-recursive -> This allows full recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$HOME` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-resource-meta-recursive"]
+          "const": "fs:allow-home-write-recursive"
         },
         {
-          "description": "fs:allow-resource-read -> This allows non-recursive read access to the `$RESOURCE` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-resource-read"]
+          "const": "fs:allow-localdata-meta"
         },
         {
-          "description": "fs:allow-resource-read-recursive -> This allows full recursive read access to the complete `$RESOURCE` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-resource-read-recursive"]
+          "const": "fs:allow-localdata-meta-recursive"
         },
         {
-          "description": "fs:allow-resource-write -> This allows non-recursive write access to the `$RESOURCE` folder.",
+          "description": "This allows non-recursive read access to the `$LOCALDATA` folder.",
           "type": "string",
-          "enum": ["fs:allow-resource-write"]
+          "const": "fs:allow-localdata-read"
         },
         {
-          "description": "fs:allow-resource-write-recursive -> This allows full recursive write access to the complete `$RESOURCE` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$LOCALDATA` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-resource-write-recursive"]
+          "const": "fs:allow-localdata-read-recursive"
         },
         {
-          "description": "fs:allow-runtime-meta -> This allows non-recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$LOCALDATA` folder.",
           "type": "string",
-          "enum": ["fs:allow-runtime-meta"]
+          "const": "fs:allow-localdata-write"
         },
         {
-          "description": "fs:allow-runtime-meta-recursive -> This allows full recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$LOCALDATA` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-runtime-meta-recursive"]
+          "const": "fs:allow-localdata-write-recursive"
         },
         {
-          "description": "fs:allow-runtime-read -> This allows non-recursive read access to the `$RUNTIME` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$LOG` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-runtime-read"]
+          "const": "fs:allow-log-meta"
         },
         {
-          "description": "fs:allow-runtime-read-recursive -> This allows full recursive read access to the complete `$RUNTIME` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$LOG` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-runtime-read-recursive"]
+          "const": "fs:allow-log-meta-recursive"
         },
         {
-          "description": "fs:allow-runtime-write -> This allows non-recursive write access to the `$RUNTIME` folder.",
+          "description": "This allows non-recursive read access to the `$LOG` folder.",
           "type": "string",
-          "enum": ["fs:allow-runtime-write"]
+          "const": "fs:allow-log-read"
         },
         {
-          "description": "fs:allow-runtime-write-recursive -> This allows full recursive write access to the complete `$RUNTIME` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$LOG` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-runtime-write-recursive"]
+          "const": "fs:allow-log-read-recursive"
         },
         {
-          "description": "fs:allow-temp-meta -> This allows non-recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$LOG` folder.",
           "type": "string",
-          "enum": ["fs:allow-temp-meta"]
+          "const": "fs:allow-log-write"
         },
         {
-          "description": "fs:allow-temp-meta-recursive -> This allows full recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$LOG` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-temp-meta-recursive"]
+          "const": "fs:allow-log-write-recursive"
         },
         {
-          "description": "fs:allow-temp-read -> This allows non-recursive read access to the `$TEMP` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-temp-read"]
+          "const": "fs:allow-picture-meta"
         },
         {
-          "description": "fs:allow-temp-read-recursive -> This allows full recursive read access to the complete `$TEMP` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-temp-read-recursive"]
+          "const": "fs:allow-picture-meta-recursive"
         },
         {
-          "description": "fs:allow-temp-write -> This allows non-recursive write access to the `$TEMP` folder.",
+          "description": "This allows non-recursive read access to the `$PICTURE` folder.",
           "type": "string",
-          "enum": ["fs:allow-temp-write"]
+          "const": "fs:allow-picture-read"
         },
         {
-          "description": "fs:allow-temp-write-recursive -> This allows full recursive write access to the complete `$TEMP` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$PICTURE` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-temp-write-recursive"]
+          "const": "fs:allow-picture-read-recursive"
         },
         {
-          "description": "fs:allow-template-meta -> This allows non-recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$PICTURE` folder.",
           "type": "string",
-          "enum": ["fs:allow-template-meta"]
+          "const": "fs:allow-picture-write"
         },
         {
-          "description": "fs:allow-template-meta-recursive -> This allows full recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$PICTURE` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-template-meta-recursive"]
+          "const": "fs:allow-picture-write-recursive"
         },
         {
-          "description": "fs:allow-template-read -> This allows non-recursive read access to the `$TEMPLATE` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-template-read"]
+          "const": "fs:allow-public-meta"
         },
         {
-          "description": "fs:allow-template-read-recursive -> This allows full recursive read access to the complete `$TEMPLATE` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-template-read-recursive"]
+          "const": "fs:allow-public-meta-recursive"
         },
         {
-          "description": "fs:allow-template-write -> This allows non-recursive write access to the `$TEMPLATE` folder.",
+          "description": "This allows non-recursive read access to the `$PUBLIC` folder.",
           "type": "string",
-          "enum": ["fs:allow-template-write"]
+          "const": "fs:allow-public-read"
         },
         {
-          "description": "fs:allow-template-write-recursive -> This allows full recursive write access to the complete `$TEMPLATE` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$PUBLIC` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-template-write-recursive"]
+          "const": "fs:allow-public-read-recursive"
         },
         {
-          "description": "fs:allow-video-meta -> This allows non-recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.",
+          "description": "This allows non-recursive write access to the `$PUBLIC` folder.",
           "type": "string",
-          "enum": ["fs:allow-video-meta"]
+          "const": "fs:allow-public-write"
         },
         {
-          "description": "fs:allow-video-meta-recursive -> This allows full recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.",
+          "description": "This allows full recursive write access to the complete `$PUBLIC` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-video-meta-recursive"]
+          "const": "fs:allow-public-write-recursive"
         },
         {
-          "description": "fs:allow-video-read -> This allows non-recursive read access to the `$VIDEO` folder.",
+          "description": "This allows non-recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-video-read"]
+          "const": "fs:allow-resource-meta"
         },
         {
-          "description": "fs:allow-video-read-recursive -> This allows full recursive read access to the complete `$VIDEO` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-video-read-recursive"]
+          "const": "fs:allow-resource-meta-recursive"
         },
         {
-          "description": "fs:allow-video-write -> This allows non-recursive write access to the `$VIDEO` folder.",
+          "description": "This allows non-recursive read access to the `$RESOURCE` folder.",
           "type": "string",
-          "enum": ["fs:allow-video-write"]
+          "const": "fs:allow-resource-read"
         },
         {
-          "description": "fs:allow-video-write-recursive -> This allows full recursive write access to the complete `$VIDEO` folder, files and subdirectories.",
+          "description": "This allows full recursive read access to the complete `$RESOURCE` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-video-write-recursive"]
+          "const": "fs:allow-resource-read-recursive"
         },
         {
-          "description": "fs:deny-default -> This denies access to dangerous Tauri relevant files and folders by default.",
+          "description": "This allows non-recursive write access to the `$RESOURCE` folder.",
           "type": "string",
-          "enum": ["fs:deny-default"]
+          "const": "fs:allow-resource-write"
         },
         {
-          "description": "fs:default -> This set of permissions describes the what kind of\nfile system access the `fs` plugin has enabled or denied by default.\n\n#### Granted Permissions\n\nThis default permission set enables read access to the\napplication specific directories (AppConfig, AppData, AppLocalData, AppCache,\nAppLog) and all files and sub directories created in it.\nThe location of these directories depends on the operating system,\nwhere the application is run.\n\nIn general these directories need to be manually created\nby the application at runtime, before accessing files or folders\nin it is possible.\n\nTherefore, it is also allowed to create all of these folders via\nthe `mkdir` command.\n\n#### Denied Permissions\n\nThis default permission set prevents access to critical components\nof the Tauri application by default.\nOn Windows the webview data folder access is denied.\n\n",
+          "description": "This allows full recursive write access to the complete `$RESOURCE` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:default"]
+          "const": "fs:allow-resource-write-recursive"
         },
         {
-          "description": "fs:allow-copy-file -> Enables the copy_file command without any pre-configured scope.",
+          "description": "This allows non-recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-copy-file"]
+          "const": "fs:allow-runtime-meta"
         },
         {
-          "description": "fs:allow-create -> Enables the create command without any pre-configured scope.",
+          "description": "This allows full recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-create"]
+          "const": "fs:allow-runtime-meta-recursive"
         },
         {
-          "description": "fs:allow-exists -> Enables the exists command without any pre-configured scope.",
+          "description": "This allows non-recursive read access to the `$RUNTIME` folder.",
           "type": "string",
-          "enum": ["fs:allow-exists"]
+          "const": "fs:allow-runtime-read"
         },
         {
-          "description": "fs:allow-fstat -> Enables the fstat command without any pre-configured scope.",
+          "description": "This allows full recursive read access to the complete `$RUNTIME` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-fstat"]
+          "const": "fs:allow-runtime-read-recursive"
         },
         {
-          "description": "fs:allow-ftruncate -> Enables the ftruncate command without any pre-configured scope.",
+          "description": "This allows non-recursive write access to the `$RUNTIME` folder.",
           "type": "string",
-          "enum": ["fs:allow-ftruncate"]
+          "const": "fs:allow-runtime-write"
         },
         {
-          "description": "fs:allow-lstat -> Enables the lstat command without any pre-configured scope.",
+          "description": "This allows full recursive write access to the complete `$RUNTIME` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-lstat"]
+          "const": "fs:allow-runtime-write-recursive"
         },
         {
-          "description": "fs:allow-mkdir -> Enables the mkdir command without any pre-configured scope.",
+          "description": "This allows non-recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-mkdir"]
+          "const": "fs:allow-temp-meta"
         },
         {
-          "description": "fs:allow-open -> Enables the open command without any pre-configured scope.",
+          "description": "This allows full recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-open"]
+          "const": "fs:allow-temp-meta-recursive"
         },
         {
-          "description": "fs:allow-read -> Enables the read command without any pre-configured scope.",
+          "description": "This allows non-recursive read access to the `$TEMP` folder.",
           "type": "string",
-          "enum": ["fs:allow-read"]
+          "const": "fs:allow-temp-read"
         },
         {
-          "description": "fs:allow-read-dir -> Enables the read_dir command without any pre-configured scope.",
+          "description": "This allows full recursive read access to the complete `$TEMP` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-read-dir"]
+          "const": "fs:allow-temp-read-recursive"
         },
         {
-          "description": "fs:allow-read-file -> Enables the read_file command without any pre-configured scope.",
+          "description": "This allows non-recursive write access to the `$TEMP` folder.",
           "type": "string",
-          "enum": ["fs:allow-read-file"]
+          "const": "fs:allow-temp-write"
         },
         {
-          "description": "fs:allow-read-text-file -> Enables the read_text_file command without any pre-configured scope.",
+          "description": "This allows full recursive write access to the complete `$TEMP` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-read-text-file"]
+          "const": "fs:allow-temp-write-recursive"
         },
         {
-          "description": "fs:allow-read-text-file-lines -> Enables the read_text_file_lines command without any pre-configured scope.",
+          "description": "This allows non-recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-read-text-file-lines"]
+          "const": "fs:allow-template-meta"
         },
         {
-          "description": "fs:allow-read-text-file-lines-next -> Enables the read_text_file_lines_next command without any pre-configured scope.",
+          "description": "This allows full recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-read-text-file-lines-next"]
+          "const": "fs:allow-template-meta-recursive"
         },
         {
-          "description": "fs:allow-remove -> Enables the remove command without any pre-configured scope.",
+          "description": "This allows non-recursive read access to the `$TEMPLATE` folder.",
           "type": "string",
-          "enum": ["fs:allow-remove"]
+          "const": "fs:allow-template-read"
         },
         {
-          "description": "fs:allow-rename -> Enables the rename command without any pre-configured scope.",
+          "description": "This allows full recursive read access to the complete `$TEMPLATE` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-rename"]
+          "const": "fs:allow-template-read-recursive"
         },
         {
-          "description": "fs:allow-seek -> Enables the seek command without any pre-configured scope.",
+          "description": "This allows non-recursive write access to the `$TEMPLATE` folder.",
           "type": "string",
-          "enum": ["fs:allow-seek"]
+          "const": "fs:allow-template-write"
         },
         {
-          "description": "fs:allow-stat -> Enables the stat command without any pre-configured scope.",
+          "description": "This allows full recursive write access to the complete `$TEMPLATE` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-stat"]
+          "const": "fs:allow-template-write-recursive"
         },
         {
-          "description": "fs:allow-truncate -> Enables the truncate command without any pre-configured scope.",
+          "description": "This allows non-recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-truncate"]
+          "const": "fs:allow-video-meta"
         },
         {
-          "description": "fs:allow-unwatch -> Enables the unwatch command without any pre-configured scope.",
+          "description": "This allows full recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.",
           "type": "string",
-          "enum": ["fs:allow-unwatch"]
+          "const": "fs:allow-video-meta-recursive"
         },
         {
-          "description": "fs:allow-watch -> Enables the watch command without any pre-configured scope.",
+          "description": "This allows non-recursive read access to the `$VIDEO` folder.",
           "type": "string",
-          "enum": ["fs:allow-watch"]
+          "const": "fs:allow-video-read"
         },
         {
-          "description": "fs:allow-write -> Enables the write command without any pre-configured scope.",
+          "description": "This allows full recursive read access to the complete `$VIDEO` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-write"]
+          "const": "fs:allow-video-read-recursive"
         },
         {
-          "description": "fs:allow-write-file -> Enables the write_file command without any pre-configured scope.",
+          "description": "This allows non-recursive write access to the `$VIDEO` folder.",
           "type": "string",
-          "enum": ["fs:allow-write-file"]
+          "const": "fs:allow-video-write"
         },
         {
-          "description": "fs:allow-write-text-file -> Enables the write_text_file command without any pre-configured scope.",
+          "description": "This allows full recursive write access to the complete `$VIDEO` folder, files and subdirectories.",
           "type": "string",
-          "enum": ["fs:allow-write-text-file"]
+          "const": "fs:allow-video-write-recursive"
         },
         {
-          "description": "fs:create-app-specific-dirs -> This permissions allows to create the application specific directories.\n",
+          "description": "This denies access to dangerous Tauri relevant files and folders by default.",
           "type": "string",
-          "enum": ["fs:create-app-specific-dirs"]
+          "const": "fs:deny-default"
         },
         {
-          "description": "fs:deny-copy-file -> Denies the copy_file command without any pre-configured scope.",
+          "description": "Enables the copy_file command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-copy-file"]
+          "const": "fs:allow-copy-file"
         },
         {
-          "description": "fs:deny-create -> Denies the create command without any pre-configured scope.",
+          "description": "Enables the create command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-create"]
+          "const": "fs:allow-create"
         },
         {
-          "description": "fs:deny-exists -> Denies the exists command without any pre-configured scope.",
+          "description": "Enables the exists command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-exists"]
+          "const": "fs:allow-exists"
         },
         {
-          "description": "fs:deny-fstat -> Denies the fstat command without any pre-configured scope.",
+          "description": "Enables the fstat command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-fstat"]
+          "const": "fs:allow-fstat"
         },
         {
-          "description": "fs:deny-ftruncate -> Denies the ftruncate command without any pre-configured scope.",
+          "description": "Enables the ftruncate command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-ftruncate"]
+          "const": "fs:allow-ftruncate"
         },
         {
-          "description": "fs:deny-lstat -> Denies the lstat command without any pre-configured scope.",
+          "description": "Enables the lstat command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-lstat"]
+          "const": "fs:allow-lstat"
         },
         {
-          "description": "fs:deny-mkdir -> Denies the mkdir command without any pre-configured scope.",
+          "description": "Enables the mkdir command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-mkdir"]
+          "const": "fs:allow-mkdir"
         },
         {
-          "description": "fs:deny-open -> Denies the open command without any pre-configured scope.",
+          "description": "Enables the open command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-open"]
+          "const": "fs:allow-open"
         },
         {
-          "description": "fs:deny-read -> Denies the read command without any pre-configured scope.",
+          "description": "Enables the read command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-read"]
+          "const": "fs:allow-read"
         },
         {
-          "description": "fs:deny-read-dir -> Denies the read_dir command without any pre-configured scope.",
+          "description": "Enables the read_dir command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-read-dir"]
+          "const": "fs:allow-read-dir"
         },
         {
-          "description": "fs:deny-read-file -> Denies the read_file command without any pre-configured scope.",
+          "description": "Enables the read_file command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-read-file"]
+          "const": "fs:allow-read-file"
         },
         {
-          "description": "fs:deny-read-text-file -> Denies the read_text_file command without any pre-configured scope.",
+          "description": "Enables the read_text_file command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-read-text-file"]
+          "const": "fs:allow-read-text-file"
         },
         {
-          "description": "fs:deny-read-text-file-lines -> Denies the read_text_file_lines command without any pre-configured scope.",
+          "description": "Enables the read_text_file_lines command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-read-text-file-lines"]
+          "const": "fs:allow-read-text-file-lines"
         },
         {
-          "description": "fs:deny-read-text-file-lines-next -> Denies the read_text_file_lines_next command without any pre-configured scope.",
+          "description": "Enables the read_text_file_lines_next command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-read-text-file-lines-next"]
+          "const": "fs:allow-read-text-file-lines-next"
         },
         {
-          "description": "fs:deny-remove -> Denies the remove command without any pre-configured scope.",
+          "description": "Enables the remove command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-remove"]
+          "const": "fs:allow-remove"
         },
         {
-          "description": "fs:deny-rename -> Denies the rename command without any pre-configured scope.",
+          "description": "Enables the rename command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-rename"]
+          "const": "fs:allow-rename"
         },
         {
-          "description": "fs:deny-seek -> Denies the seek command without any pre-configured scope.",
+          "description": "Enables the seek command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-seek"]
+          "const": "fs:allow-seek"
         },
         {
-          "description": "fs:deny-stat -> Denies the stat command without any pre-configured scope.",
+          "description": "Enables the size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-stat"]
+          "const": "fs:allow-size"
         },
         {
-          "description": "fs:deny-truncate -> Denies the truncate command without any pre-configured scope.",
+          "description": "Enables the stat command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-truncate"]
+          "const": "fs:allow-stat"
         },
         {
-          "description": "fs:deny-unwatch -> Denies the unwatch command without any pre-configured scope.",
+          "description": "Enables the truncate command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-unwatch"]
+          "const": "fs:allow-truncate"
         },
         {
-          "description": "fs:deny-watch -> Denies the watch command without any pre-configured scope.",
+          "description": "Enables the unwatch command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-watch"]
+          "const": "fs:allow-unwatch"
         },
         {
-          "description": "fs:deny-webview-data-linux -> This denies read access to the\n`$APPLOCALDATA` folder on linux as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
+          "description": "Enables the watch command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-webview-data-linux"]
+          "const": "fs:allow-watch"
         },
         {
-          "description": "fs:deny-webview-data-windows -> This denies read access to the\n`$APPLOCALDATA/EBWebView` folder on windows as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
+          "description": "Enables the write command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-webview-data-windows"]
+          "const": "fs:allow-write"
         },
         {
-          "description": "fs:deny-write -> Denies the write command without any pre-configured scope.",
+          "description": "Enables the write_file command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-write"]
+          "const": "fs:allow-write-file"
         },
         {
-          "description": "fs:deny-write-file -> Denies the write_file command without any pre-configured scope.",
+          "description": "Enables the write_text_file command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:deny-write-file"]
+          "const": "fs:allow-write-text-file"
         },
         {
-          "description": "fs:deny-write-text-file -> Denies the write_text_file command without any pre-configured scope.",
+          "description": "This permissions allows to create the application specific directories.\n",
           "type": "string",
-          "enum": ["fs:deny-write-text-file"]
+          "const": "fs:create-app-specific-dirs"
         },
         {
-          "description": "fs:read-all -> This enables all read related commands without any pre-configured accessible paths.",
+          "description": "Denies the copy_file command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:read-all"]
+          "const": "fs:deny-copy-file"
         },
         {
-          "description": "fs:read-app-specific-dirs-recursive -> This permission allows recursive read functionality on the application\nspecific base directories. \n",
+          "description": "Denies the create command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:read-app-specific-dirs-recursive"]
+          "const": "fs:deny-create"
         },
         {
-          "description": "fs:read-dirs -> This enables directory read and file metadata related commands without any pre-configured accessible paths.",
+          "description": "Denies the exists command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:read-dirs"]
+          "const": "fs:deny-exists"
         },
         {
-          "description": "fs:read-files -> This enables file read related commands without any pre-configured accessible paths.",
+          "description": "Denies the fstat command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:read-files"]
+          "const": "fs:deny-fstat"
         },
         {
-          "description": "fs:read-meta -> This enables all index or metadata related commands without any pre-configured accessible paths.",
+          "description": "Denies the ftruncate command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:read-meta"]
+          "const": "fs:deny-ftruncate"
         },
         {
-          "description": "fs:scope -> An empty permission you can use to modify the global scope.",
+          "description": "Denies the lstat command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope"]
+          "const": "fs:deny-lstat"
         },
         {
-          "description": "fs:scope-app -> This scope permits access to all files and list content of top level directories in the `$APP`folder.",
+          "description": "Denies the mkdir command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-app"]
+          "const": "fs:deny-mkdir"
         },
         {
-          "description": "fs:scope-app-index -> This scope permits to list all files and folders in the `$APP`folder.",
+          "description": "Denies the open command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-app-index"]
+          "const": "fs:deny-open"
         },
         {
-          "description": "fs:scope-app-recursive -> This scope permits recursive access to the complete `$APP` folder, including sub directories and files.",
+          "description": "Denies the read command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-app-recursive"]
+          "const": "fs:deny-read"
         },
         {
-          "description": "fs:scope-appcache -> This scope permits access to all files and list content of top level directories in the `$APPCACHE`folder.",
+          "description": "Denies the read_dir command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-appcache"]
+          "const": "fs:deny-read-dir"
         },
         {
-          "description": "fs:scope-appcache-index -> This scope permits to list all files and folders in the `$APPCACHE`folder.",
+          "description": "Denies the read_file command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-appcache-index"]
+          "const": "fs:deny-read-file"
         },
         {
-          "description": "fs:scope-appcache-recursive -> This scope permits recursive access to the complete `$APPCACHE` folder, including sub directories and files.",
+          "description": "Denies the read_text_file command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-appcache-recursive"]
+          "const": "fs:deny-read-text-file"
         },
         {
-          "description": "fs:scope-appconfig -> This scope permits access to all files and list content of top level directories in the `$APPCONFIG`folder.",
+          "description": "Denies the read_text_file_lines command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-appconfig"]
+          "const": "fs:deny-read-text-file-lines"
         },
         {
-          "description": "fs:scope-appconfig-index -> This scope permits to list all files and folders in the `$APPCONFIG`folder.",
+          "description": "Denies the read_text_file_lines_next command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-appconfig-index"]
+          "const": "fs:deny-read-text-file-lines-next"
         },
         {
-          "description": "fs:scope-appconfig-recursive -> This scope permits recursive access to the complete `$APPCONFIG` folder, including sub directories and files.",
+          "description": "Denies the remove command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-appconfig-recursive"]
+          "const": "fs:deny-remove"
         },
         {
-          "description": "fs:scope-appdata -> This scope permits access to all files and list content of top level directories in the `$APPDATA`folder.",
+          "description": "Denies the rename command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-appdata"]
+          "const": "fs:deny-rename"
         },
         {
-          "description": "fs:scope-appdata-index -> This scope permits to list all files and folders in the `$APPDATA`folder.",
+          "description": "Denies the seek command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-appdata-index"]
+          "const": "fs:deny-seek"
         },
         {
-          "description": "fs:scope-appdata-recursive -> This scope permits recursive access to the complete `$APPDATA` folder, including sub directories and files.",
+          "description": "Denies the size command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-appdata-recursive"]
+          "const": "fs:deny-size"
         },
         {
-          "description": "fs:scope-applocaldata -> This scope permits access to all files and list content of top level directories in the `$APPLOCALDATA`folder.",
+          "description": "Denies the stat command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-applocaldata"]
+          "const": "fs:deny-stat"
         },
         {
-          "description": "fs:scope-applocaldata-index -> This scope permits to list all files and folders in the `$APPLOCALDATA`folder.",
+          "description": "Denies the truncate command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-applocaldata-index"]
+          "const": "fs:deny-truncate"
         },
         {
-          "description": "fs:scope-applocaldata-recursive -> This scope permits recursive access to the complete `$APPLOCALDATA` folder, including sub directories and files.",
+          "description": "Denies the unwatch command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-applocaldata-recursive"]
+          "const": "fs:deny-unwatch"
         },
         {
-          "description": "fs:scope-applog -> This scope permits access to all files and list content of top level directories in the `$APPLOG`folder.",
+          "description": "Denies the watch command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-applog"]
+          "const": "fs:deny-watch"
         },
         {
-          "description": "fs:scope-applog-index -> This scope permits to list all files and folders in the `$APPLOG`folder.",
+          "description": "This denies read access to the\n`$APPLOCALDATA` folder on linux as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
           "type": "string",
-          "enum": ["fs:scope-applog-index"]
+          "const": "fs:deny-webview-data-linux"
         },
         {
-          "description": "fs:scope-applog-recursive -> This scope permits recursive access to the complete `$APPLOG` folder, including sub directories and files.",
+          "description": "This denies read access to the\n`$APPLOCALDATA/EBWebView` folder on windows as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
           "type": "string",
-          "enum": ["fs:scope-applog-recursive"]
+          "const": "fs:deny-webview-data-windows"
         },
         {
-          "description": "fs:scope-audio -> This scope permits access to all files and list content of top level directories in the `$AUDIO`folder.",
+          "description": "Denies the write command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-audio"]
+          "const": "fs:deny-write"
         },
         {
-          "description": "fs:scope-audio-index -> This scope permits to list all files and folders in the `$AUDIO`folder.",
+          "description": "Denies the write_file command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-audio-index"]
+          "const": "fs:deny-write-file"
         },
         {
-          "description": "fs:scope-audio-recursive -> This scope permits recursive access to the complete `$AUDIO` folder, including sub directories and files.",
+          "description": "Denies the write_text_file command without any pre-configured scope.",
           "type": "string",
-          "enum": ["fs:scope-audio-recursive"]
+          "const": "fs:deny-write-text-file"
         },
         {
-          "description": "fs:scope-cache -> This scope permits access to all files and list content of top level directories in the `$CACHE`folder.",
+          "description": "This enables all read related commands without any pre-configured accessible paths.",
           "type": "string",
-          "enum": ["fs:scope-cache"]
+          "const": "fs:read-all"
         },
         {
-          "description": "fs:scope-cache-index -> This scope permits to list all files and folders in the `$CACHE`folder.",
+          "description": "This permission allows recursive read functionality on the application\nspecific base directories. \n",
           "type": "string",
-          "enum": ["fs:scope-cache-index"]
+          "const": "fs:read-app-specific-dirs-recursive"
         },
         {
-          "description": "fs:scope-cache-recursive -> This scope permits recursive access to the complete `$CACHE` folder, including sub directories and files.",
+          "description": "This enables directory read and file metadata related commands without any pre-configured accessible paths.",
           "type": "string",
-          "enum": ["fs:scope-cache-recursive"]
+          "const": "fs:read-dirs"
         },
         {
-          "description": "fs:scope-config -> This scope permits access to all files and list content of top level directories in the `$CONFIG`folder.",
+          "description": "This enables file read related commands without any pre-configured accessible paths.",
           "type": "string",
-          "enum": ["fs:scope-config"]
+          "const": "fs:read-files"
         },
         {
-          "description": "fs:scope-config-index -> This scope permits to list all files and folders in the `$CONFIG`folder.",
+          "description": "This enables all index or metadata related commands without any pre-configured accessible paths.",
           "type": "string",
-          "enum": ["fs:scope-config-index"]
+          "const": "fs:read-meta"
         },
         {
-          "description": "fs:scope-config-recursive -> This scope permits recursive access to the complete `$CONFIG` folder, including sub directories and files.",
+          "description": "An empty permission you can use to modify the global scope.",
           "type": "string",
-          "enum": ["fs:scope-config-recursive"]
+          "const": "fs:scope"
         },
         {
-          "description": "fs:scope-data -> This scope permits access to all files and list content of top level directories in the `$DATA`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the application folders.",
           "type": "string",
-          "enum": ["fs:scope-data"]
+          "const": "fs:scope-app"
         },
         {
-          "description": "fs:scope-data-index -> This scope permits to list all files and folders in the `$DATA`folder.",
+          "description": "This scope permits to list all files and folders in the application directories.",
           "type": "string",
-          "enum": ["fs:scope-data-index"]
+          "const": "fs:scope-app-index"
         },
         {
-          "description": "fs:scope-data-recursive -> This scope permits recursive access to the complete `$DATA` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete application folders, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-data-recursive"]
+          "const": "fs:scope-app-recursive"
         },
         {
-          "description": "fs:scope-desktop -> This scope permits access to all files and list content of top level directories in the `$DESKTOP`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$APPCACHE` folder.",
           "type": "string",
-          "enum": ["fs:scope-desktop"]
+          "const": "fs:scope-appcache"
         },
         {
-          "description": "fs:scope-desktop-index -> This scope permits to list all files and folders in the `$DESKTOP`folder.",
+          "description": "This scope permits to list all files and folders in the `$APPCACHE`folder.",
           "type": "string",
-          "enum": ["fs:scope-desktop-index"]
+          "const": "fs:scope-appcache-index"
         },
         {
-          "description": "fs:scope-desktop-recursive -> This scope permits recursive access to the complete `$DESKTOP` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$APPCACHE` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-desktop-recursive"]
+          "const": "fs:scope-appcache-recursive"
         },
         {
-          "description": "fs:scope-document -> This scope permits access to all files and list content of top level directories in the `$DOCUMENT`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$APPCONFIG` folder.",
           "type": "string",
-          "enum": ["fs:scope-document"]
+          "const": "fs:scope-appconfig"
         },
         {
-          "description": "fs:scope-document-index -> This scope permits to list all files and folders in the `$DOCUMENT`folder.",
+          "description": "This scope permits to list all files and folders in the `$APPCONFIG`folder.",
           "type": "string",
-          "enum": ["fs:scope-document-index"]
+          "const": "fs:scope-appconfig-index"
         },
         {
-          "description": "fs:scope-document-recursive -> This scope permits recursive access to the complete `$DOCUMENT` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$APPCONFIG` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-document-recursive"]
+          "const": "fs:scope-appconfig-recursive"
         },
         {
-          "description": "fs:scope-download -> This scope permits access to all files and list content of top level directories in the `$DOWNLOAD`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$APPDATA` folder.",
           "type": "string",
-          "enum": ["fs:scope-download"]
+          "const": "fs:scope-appdata"
         },
         {
-          "description": "fs:scope-download-index -> This scope permits to list all files and folders in the `$DOWNLOAD`folder.",
+          "description": "This scope permits to list all files and folders in the `$APPDATA`folder.",
           "type": "string",
-          "enum": ["fs:scope-download-index"]
+          "const": "fs:scope-appdata-index"
         },
         {
-          "description": "fs:scope-download-recursive -> This scope permits recursive access to the complete `$DOWNLOAD` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$APPDATA` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-download-recursive"]
+          "const": "fs:scope-appdata-recursive"
         },
         {
-          "description": "fs:scope-exe -> This scope permits access to all files and list content of top level directories in the `$EXE`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$APPLOCALDATA` folder.",
           "type": "string",
-          "enum": ["fs:scope-exe"]
+          "const": "fs:scope-applocaldata"
         },
         {
-          "description": "fs:scope-exe-index -> This scope permits to list all files and folders in the `$EXE`folder.",
+          "description": "This scope permits to list all files and folders in the `$APPLOCALDATA`folder.",
           "type": "string",
-          "enum": ["fs:scope-exe-index"]
+          "const": "fs:scope-applocaldata-index"
         },
         {
-          "description": "fs:scope-exe-recursive -> This scope permits recursive access to the complete `$EXE` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$APPLOCALDATA` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-exe-recursive"]
+          "const": "fs:scope-applocaldata-recursive"
         },
         {
-          "description": "fs:scope-font -> This scope permits access to all files and list content of top level directories in the `$FONT`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$APPLOG` folder.",
           "type": "string",
-          "enum": ["fs:scope-font"]
+          "const": "fs:scope-applog"
         },
         {
-          "description": "fs:scope-font-index -> This scope permits to list all files and folders in the `$FONT`folder.",
+          "description": "This scope permits to list all files and folders in the `$APPLOG`folder.",
           "type": "string",
-          "enum": ["fs:scope-font-index"]
+          "const": "fs:scope-applog-index"
         },
         {
-          "description": "fs:scope-font-recursive -> This scope permits recursive access to the complete `$FONT` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$APPLOG` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-font-recursive"]
+          "const": "fs:scope-applog-recursive"
         },
         {
-          "description": "fs:scope-home -> This scope permits access to all files and list content of top level directories in the `$HOME`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$AUDIO` folder.",
           "type": "string",
-          "enum": ["fs:scope-home"]
+          "const": "fs:scope-audio"
         },
         {
-          "description": "fs:scope-home-index -> This scope permits to list all files and folders in the `$HOME`folder.",
+          "description": "This scope permits to list all files and folders in the `$AUDIO`folder.",
           "type": "string",
-          "enum": ["fs:scope-home-index"]
+          "const": "fs:scope-audio-index"
         },
         {
-          "description": "fs:scope-home-recursive -> This scope permits recursive access to the complete `$HOME` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$AUDIO` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-home-recursive"]
+          "const": "fs:scope-audio-recursive"
         },
         {
-          "description": "fs:scope-localdata -> This scope permits access to all files and list content of top level directories in the `$LOCALDATA`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$CACHE` folder.",
           "type": "string",
-          "enum": ["fs:scope-localdata"]
+          "const": "fs:scope-cache"
         },
         {
-          "description": "fs:scope-localdata-index -> This scope permits to list all files and folders in the `$LOCALDATA`folder.",
+          "description": "This scope permits to list all files and folders in the `$CACHE`folder.",
           "type": "string",
-          "enum": ["fs:scope-localdata-index"]
+          "const": "fs:scope-cache-index"
         },
         {
-          "description": "fs:scope-localdata-recursive -> This scope permits recursive access to the complete `$LOCALDATA` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$CACHE` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-localdata-recursive"]
+          "const": "fs:scope-cache-recursive"
         },
         {
-          "description": "fs:scope-log -> This scope permits access to all files and list content of top level directories in the `$LOG`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$CONFIG` folder.",
           "type": "string",
-          "enum": ["fs:scope-log"]
+          "const": "fs:scope-config"
         },
         {
-          "description": "fs:scope-log-index -> This scope permits to list all files and folders in the `$LOG`folder.",
+          "description": "This scope permits to list all files and folders in the `$CONFIG`folder.",
           "type": "string",
-          "enum": ["fs:scope-log-index"]
+          "const": "fs:scope-config-index"
         },
         {
-          "description": "fs:scope-log-recursive -> This scope permits recursive access to the complete `$LOG` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$CONFIG` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-log-recursive"]
+          "const": "fs:scope-config-recursive"
         },
         {
-          "description": "fs:scope-picture -> This scope permits access to all files and list content of top level directories in the `$PICTURE`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$DATA` folder.",
           "type": "string",
-          "enum": ["fs:scope-picture"]
+          "const": "fs:scope-data"
         },
         {
-          "description": "fs:scope-picture-index -> This scope permits to list all files and folders in the `$PICTURE`folder.",
+          "description": "This scope permits to list all files and folders in the `$DATA`folder.",
           "type": "string",
-          "enum": ["fs:scope-picture-index"]
+          "const": "fs:scope-data-index"
         },
         {
-          "description": "fs:scope-picture-recursive -> This scope permits recursive access to the complete `$PICTURE` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$DATA` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-picture-recursive"]
+          "const": "fs:scope-data-recursive"
         },
         {
-          "description": "fs:scope-public -> This scope permits access to all files and list content of top level directories in the `$PUBLIC`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$DESKTOP` folder.",
           "type": "string",
-          "enum": ["fs:scope-public"]
+          "const": "fs:scope-desktop"
         },
         {
-          "description": "fs:scope-public-index -> This scope permits to list all files and folders in the `$PUBLIC`folder.",
+          "description": "This scope permits to list all files and folders in the `$DESKTOP`folder.",
           "type": "string",
-          "enum": ["fs:scope-public-index"]
+          "const": "fs:scope-desktop-index"
         },
         {
-          "description": "fs:scope-public-recursive -> This scope permits recursive access to the complete `$PUBLIC` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$DESKTOP` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-public-recursive"]
+          "const": "fs:scope-desktop-recursive"
         },
         {
-          "description": "fs:scope-resource -> This scope permits access to all files and list content of top level directories in the `$RESOURCE`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$DOCUMENT` folder.",
           "type": "string",
-          "enum": ["fs:scope-resource"]
+          "const": "fs:scope-document"
         },
         {
-          "description": "fs:scope-resource-index -> This scope permits to list all files and folders in the `$RESOURCE`folder.",
+          "description": "This scope permits to list all files and folders in the `$DOCUMENT`folder.",
           "type": "string",
-          "enum": ["fs:scope-resource-index"]
+          "const": "fs:scope-document-index"
         },
         {
-          "description": "fs:scope-resource-recursive -> This scope permits recursive access to the complete `$RESOURCE` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$DOCUMENT` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-resource-recursive"]
+          "const": "fs:scope-document-recursive"
         },
         {
-          "description": "fs:scope-runtime -> This scope permits access to all files and list content of top level directories in the `$RUNTIME`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$DOWNLOAD` folder.",
           "type": "string",
-          "enum": ["fs:scope-runtime"]
+          "const": "fs:scope-download"
         },
         {
-          "description": "fs:scope-runtime-index -> This scope permits to list all files and folders in the `$RUNTIME`folder.",
+          "description": "This scope permits to list all files and folders in the `$DOWNLOAD`folder.",
           "type": "string",
-          "enum": ["fs:scope-runtime-index"]
+          "const": "fs:scope-download-index"
         },
         {
-          "description": "fs:scope-runtime-recursive -> This scope permits recursive access to the complete `$RUNTIME` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$DOWNLOAD` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-runtime-recursive"]
+          "const": "fs:scope-download-recursive"
         },
         {
-          "description": "fs:scope-temp -> This scope permits access to all files and list content of top level directories in the `$TEMP`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$EXE` folder.",
           "type": "string",
-          "enum": ["fs:scope-temp"]
+          "const": "fs:scope-exe"
         },
         {
-          "description": "fs:scope-temp-index -> This scope permits to list all files and folders in the `$TEMP`folder.",
+          "description": "This scope permits to list all files and folders in the `$EXE`folder.",
           "type": "string",
-          "enum": ["fs:scope-temp-index"]
+          "const": "fs:scope-exe-index"
         },
         {
-          "description": "fs:scope-temp-recursive -> This scope permits recursive access to the complete `$TEMP` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$EXE` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-temp-recursive"]
+          "const": "fs:scope-exe-recursive"
         },
         {
-          "description": "fs:scope-template -> This scope permits access to all files and list content of top level directories in the `$TEMPLATE`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$FONT` folder.",
           "type": "string",
-          "enum": ["fs:scope-template"]
+          "const": "fs:scope-font"
         },
         {
-          "description": "fs:scope-template-index -> This scope permits to list all files and folders in the `$TEMPLATE`folder.",
+          "description": "This scope permits to list all files and folders in the `$FONT`folder.",
           "type": "string",
-          "enum": ["fs:scope-template-index"]
+          "const": "fs:scope-font-index"
         },
         {
-          "description": "fs:scope-template-recursive -> This scope permits recursive access to the complete `$TEMPLATE` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$FONT` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-template-recursive"]
+          "const": "fs:scope-font-recursive"
         },
         {
-          "description": "fs:scope-video -> This scope permits access to all files and list content of top level directories in the `$VIDEO`folder.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$HOME` folder.",
           "type": "string",
-          "enum": ["fs:scope-video"]
+          "const": "fs:scope-home"
         },
         {
-          "description": "fs:scope-video-index -> This scope permits to list all files and folders in the `$VIDEO`folder.",
+          "description": "This scope permits to list all files and folders in the `$HOME`folder.",
           "type": "string",
-          "enum": ["fs:scope-video-index"]
+          "const": "fs:scope-home-index"
         },
         {
-          "description": "fs:scope-video-recursive -> This scope permits recursive access to the complete `$VIDEO` folder, including sub directories and files.",
+          "description": "This scope permits recursive access to the complete `$HOME` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["fs:scope-video-recursive"]
+          "const": "fs:scope-home-recursive"
         },
         {
-          "description": "fs:write-all -> This enables all write related commands without any pre-configured accessible paths.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$LOCALDATA` folder.",
           "type": "string",
-          "enum": ["fs:write-all"]
+          "const": "fs:scope-localdata"
         },
         {
-          "description": "fs:write-files -> This enables all file write related commands without any pre-configured accessible paths.",
+          "description": "This scope permits to list all files and folders in the `$LOCALDATA`folder.",
           "type": "string",
-          "enum": ["fs:write-files"]
+          "const": "fs:scope-localdata-index"
         },
         {
-          "description": "http:default -> This permission set configures what kind of\nfetch operations are available from the http plugin.\n\nThis enables all fetch operations but does not\nallow explicitly any origins to be fetched. This needs to\nbe manually configured before usage.\n\n#### Granted Permissions\n\nAll fetch operations are enabled.\n\n",
+          "description": "This scope permits recursive access to the complete `$LOCALDATA` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["http:default"]
+          "const": "fs:scope-localdata-recursive"
         },
         {
-          "description": "http:allow-fetch -> Enables the fetch command without any pre-configured scope.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$LOG` folder.",
           "type": "string",
-          "enum": ["http:allow-fetch"]
+          "const": "fs:scope-log"
         },
         {
-          "description": "http:allow-fetch-cancel -> Enables the fetch_cancel command without any pre-configured scope.",
+          "description": "This scope permits to list all files and folders in the `$LOG`folder.",
           "type": "string",
-          "enum": ["http:allow-fetch-cancel"]
+          "const": "fs:scope-log-index"
         },
         {
-          "description": "http:allow-fetch-read-body -> Enables the fetch_read_body command without any pre-configured scope.",
+          "description": "This scope permits recursive access to the complete `$LOG` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["http:allow-fetch-read-body"]
+          "const": "fs:scope-log-recursive"
         },
         {
-          "description": "http:allow-fetch-send -> Enables the fetch_send command without any pre-configured scope.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$PICTURE` folder.",
           "type": "string",
-          "enum": ["http:allow-fetch-send"]
+          "const": "fs:scope-picture"
         },
         {
-          "description": "http:deny-fetch -> Denies the fetch command without any pre-configured scope.",
+          "description": "This scope permits to list all files and folders in the `$PICTURE`folder.",
           "type": "string",
-          "enum": ["http:deny-fetch"]
+          "const": "fs:scope-picture-index"
         },
         {
-          "description": "http:deny-fetch-cancel -> Denies the fetch_cancel command without any pre-configured scope.",
+          "description": "This scope permits recursive access to the complete `$PICTURE` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["http:deny-fetch-cancel"]
+          "const": "fs:scope-picture-recursive"
         },
         {
-          "description": "http:deny-fetch-read-body -> Denies the fetch_read_body command without any pre-configured scope.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$PUBLIC` folder.",
           "type": "string",
-          "enum": ["http:deny-fetch-read-body"]
+          "const": "fs:scope-public"
         },
         {
-          "description": "http:deny-fetch-send -> Denies the fetch_send command without any pre-configured scope.",
+          "description": "This scope permits to list all files and folders in the `$PUBLIC`folder.",
           "type": "string",
-          "enum": ["http:deny-fetch-send"]
+          "const": "fs:scope-public-index"
         },
         {
-          "description": "os:default -> This permission set configures which\noperating system information are available\nto gather from the frontend.\n\n#### Granted Permissions\n\nAll information except the host name are available.\n\n",
+          "description": "This scope permits recursive access to the complete `$PUBLIC` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["os:default"]
+          "const": "fs:scope-public-recursive"
         },
         {
-          "description": "os:allow-arch -> Enables the arch command without any pre-configured scope.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$RESOURCE` folder.",
           "type": "string",
-          "enum": ["os:allow-arch"]
+          "const": "fs:scope-resource"
         },
         {
-          "description": "os:allow-exe-extension -> Enables the exe_extension command without any pre-configured scope.",
+          "description": "This scope permits to list all files and folders in the `$RESOURCE`folder.",
           "type": "string",
-          "enum": ["os:allow-exe-extension"]
+          "const": "fs:scope-resource-index"
         },
         {
-          "description": "os:allow-family -> Enables the family command without any pre-configured scope.",
+          "description": "This scope permits recursive access to the complete `$RESOURCE` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["os:allow-family"]
+          "const": "fs:scope-resource-recursive"
         },
         {
-          "description": "os:allow-hostname -> Enables the hostname command without any pre-configured scope.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$RUNTIME` folder.",
           "type": "string",
-          "enum": ["os:allow-hostname"]
+          "const": "fs:scope-runtime"
         },
         {
-          "description": "os:allow-locale -> Enables the locale command without any pre-configured scope.",
+          "description": "This scope permits to list all files and folders in the `$RUNTIME`folder.",
           "type": "string",
-          "enum": ["os:allow-locale"]
+          "const": "fs:scope-runtime-index"
         },
         {
-          "description": "os:allow-os-type -> Enables the os_type command without any pre-configured scope.",
+          "description": "This scope permits recursive access to the complete `$RUNTIME` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["os:allow-os-type"]
+          "const": "fs:scope-runtime-recursive"
         },
         {
-          "description": "os:allow-platform -> Enables the platform command without any pre-configured scope.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$TEMP` folder.",
           "type": "string",
-          "enum": ["os:allow-platform"]
+          "const": "fs:scope-temp"
         },
         {
-          "description": "os:allow-version -> Enables the version command without any pre-configured scope.",
+          "description": "This scope permits to list all files and folders in the `$TEMP`folder.",
           "type": "string",
-          "enum": ["os:allow-version"]
+          "const": "fs:scope-temp-index"
         },
         {
-          "description": "os:deny-arch -> Denies the arch command without any pre-configured scope.",
+          "description": "This scope permits recursive access to the complete `$TEMP` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["os:deny-arch"]
+          "const": "fs:scope-temp-recursive"
         },
         {
-          "description": "os:deny-exe-extension -> Denies the exe_extension command without any pre-configured scope.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$TEMPLATE` folder.",
           "type": "string",
-          "enum": ["os:deny-exe-extension"]
+          "const": "fs:scope-template"
         },
         {
-          "description": "os:deny-family -> Denies the family command without any pre-configured scope.",
+          "description": "This scope permits to list all files and folders in the `$TEMPLATE`folder.",
           "type": "string",
-          "enum": ["os:deny-family"]
+          "const": "fs:scope-template-index"
         },
         {
-          "description": "os:deny-hostname -> Denies the hostname command without any pre-configured scope.",
+          "description": "This scope permits recursive access to the complete `$TEMPLATE` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["os:deny-hostname"]
+          "const": "fs:scope-template-recursive"
         },
         {
-          "description": "os:deny-locale -> Denies the locale command without any pre-configured scope.",
+          "description": "This scope permits access to all files and list content of top level directories in the `$VIDEO` folder.",
           "type": "string",
-          "enum": ["os:deny-locale"]
+          "const": "fs:scope-video"
         },
         {
-          "description": "os:deny-os-type -> Denies the os_type command without any pre-configured scope.",
+          "description": "This scope permits to list all files and folders in the `$VIDEO`folder.",
           "type": "string",
-          "enum": ["os:deny-os-type"]
+          "const": "fs:scope-video-index"
         },
         {
-          "description": "os:deny-platform -> Denies the platform command without any pre-configured scope.",
+          "description": "This scope permits recursive access to the complete `$VIDEO` folder, including sub directories and files.",
           "type": "string",
-          "enum": ["os:deny-platform"]
+          "const": "fs:scope-video-recursive"
         },
         {
-          "description": "os:deny-version -> Denies the version command without any pre-configured scope.",
+          "description": "This enables all write related commands without any pre-configured accessible paths.",
           "type": "string",
-          "enum": ["os:deny-version"]
+          "const": "fs:write-all"
         },
         {
-          "description": "process:default -> This permission set configures which\nprocess feeatures are by default exposed.\n\n#### Granted Permissions\n\nThis enables to quit via `allow-exit` and restart via `allow-restart`\nthe application.\n",
+          "description": "This enables all file write related commands without any pre-configured accessible paths.",
           "type": "string",
-          "enum": ["process:default"]
+          "const": "fs:write-files"
         },
         {
-          "description": "process:allow-exit -> Enables the exit command without any pre-configured scope.",
+          "description": "This permission set configures what kind of\nfetch operations are available from the http plugin.\n\nThis enables all fetch operations but does not\nallow explicitly any origins to be fetched. This needs to\nbe manually configured before usage.\n\n#### Granted Permissions\n\nAll fetch operations are enabled.\n\n",
           "type": "string",
-          "enum": ["process:allow-exit"]
+          "const": "http:default"
         },
         {
-          "description": "process:allow-restart -> Enables the restart command without any pre-configured scope.",
+          "description": "Enables the fetch command without any pre-configured scope.",
           "type": "string",
-          "enum": ["process:allow-restart"]
+          "const": "http:allow-fetch"
         },
         {
-          "description": "process:deny-exit -> Denies the exit command without any pre-configured scope.",
+          "description": "Enables the fetch_cancel command without any pre-configured scope.",
           "type": "string",
-          "enum": ["process:deny-exit"]
+          "const": "http:allow-fetch-cancel"
         },
         {
-          "description": "process:deny-restart -> Denies the restart command without any pre-configured scope.",
+          "description": "Enables the fetch_read_body command without any pre-configured scope.",
           "type": "string",
-          "enum": ["process:deny-restart"]
+          "const": "http:allow-fetch-read-body"
         },
         {
-          "description": "shell:default -> This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality without any specific\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n",
+          "description": "Enables the fetch_send command without any pre-configured scope.",
           "type": "string",
-          "enum": ["shell:default"]
+          "const": "http:allow-fetch-send"
         },
         {
-          "description": "shell:allow-execute -> Enables the execute command without any pre-configured scope.",
+          "description": "Denies the fetch command without any pre-configured scope.",
           "type": "string",
-          "enum": ["shell:allow-execute"]
+          "const": "http:deny-fetch"
         },
         {
-          "description": "shell:allow-kill -> Enables the kill command without any pre-configured scope.",
+          "description": "Denies the fetch_cancel command without any pre-configured scope.",
           "type": "string",
-          "enum": ["shell:allow-kill"]
+          "const": "http:deny-fetch-cancel"
         },
         {
-          "description": "shell:allow-open -> Enables the open command without any pre-configured scope.",
+          "description": "Denies the fetch_read_body command without any pre-configured scope.",
           "type": "string",
-          "enum": ["shell:allow-open"]
+          "const": "http:deny-fetch-read-body"
         },
         {
-          "description": "shell:allow-spawn -> Enables the spawn command without any pre-configured scope.",
+          "description": "Denies the fetch_send command without any pre-configured scope.",
           "type": "string",
-          "enum": ["shell:allow-spawn"]
+          "const": "http:deny-fetch-send"
         },
         {
-          "description": "shell:allow-stdin-write -> Enables the stdin_write command without any pre-configured scope.",
+          "description": "Allows the log command",
           "type": "string",
-          "enum": ["shell:allow-stdin-write"]
+          "const": "log:default"
         },
         {
-          "description": "shell:deny-execute -> Denies the execute command without any pre-configured scope.",
+          "description": "Enables the log command without any pre-configured scope.",
           "type": "string",
-          "enum": ["shell:deny-execute"]
+          "const": "log:allow-log"
         },
         {
-          "description": "shell:deny-kill -> Denies the kill command without any pre-configured scope.",
+          "description": "Denies the log command without any pre-configured scope.",
           "type": "string",
-          "enum": ["shell:deny-kill"]
+          "const": "log:deny-log"
         },
         {
-          "description": "shell:deny-open -> Denies the open command without any pre-configured scope.",
+          "description": "This permission set configures which\nnotification features are by default exposed.\n\n#### Granted Permissions\n\nIt allows all notification related features.\n\n",
           "type": "string",
-          "enum": ["shell:deny-open"]
+          "const": "notification:default"
         },
         {
-          "description": "shell:deny-spawn -> Denies the spawn command without any pre-configured scope.",
+          "description": "Enables the batch command without any pre-configured scope.",
           "type": "string",
-          "enum": ["shell:deny-spawn"]
+          "const": "notification:allow-batch"
         },
         {
-          "description": "shell:deny-stdin-write -> Denies the stdin_write command without any pre-configured scope.",
+          "description": "Enables the cancel command without any pre-configured scope.",
           "type": "string",
-          "enum": ["shell:deny-stdin-write"]
+          "const": "notification:allow-cancel"
         },
         {
-          "description": "updater:default -> This permission set configures which kind of\nupdater functions are exposed to the frontend.\n\n#### Granted Permissions\n\nThe full workflow from checking for updates to installing them\nis enabled.\n\n",
+          "description": "Enables the check_permissions command without any pre-configured scope.",
           "type": "string",
-          "enum": ["updater:default"]
+          "const": "notification:allow-check-permissions"
         },
         {
-          "description": "updater:allow-check -> Enables the check command without any pre-configured scope.",
+          "description": "Enables the create_channel command without any pre-configured scope.",
           "type": "string",
-          "enum": ["updater:allow-check"]
+          "const": "notification:allow-create-channel"
         },
         {
-          "description": "updater:allow-download -> Enables the download command without any pre-configured scope.",
+          "description": "Enables the delete_channel command without any pre-configured scope.",
           "type": "string",
-          "enum": ["updater:allow-download"]
+          "const": "notification:allow-delete-channel"
         },
         {
-          "description": "updater:allow-download-and-install -> Enables the download_and_install command without any pre-configured scope.",
+          "description": "Enables the get_active command without any pre-configured scope.",
           "type": "string",
-          "enum": ["updater:allow-download-and-install"]
+          "const": "notification:allow-get-active"
         },
         {
-          "description": "updater:allow-install -> Enables the install command without any pre-configured scope.",
+          "description": "Enables the get_pending command without any pre-configured scope.",
           "type": "string",
-          "enum": ["updater:allow-install"]
+          "const": "notification:allow-get-pending"
         },
         {
-          "description": "updater:deny-check -> Denies the check command without any pre-configured scope.",
+          "description": "Enables the is_permission_granted command without any pre-configured scope.",
           "type": "string",
-          "enum": ["updater:deny-check"]
+          "const": "notification:allow-is-permission-granted"
         },
         {
-          "description": "updater:deny-download -> Denies the download command without any pre-configured scope.",
+          "description": "Enables the list_channels command without any pre-configured scope.",
           "type": "string",
-          "enum": ["updater:deny-download"]
+          "const": "notification:allow-list-channels"
         },
         {
-          "description": "updater:deny-download-and-install -> Denies the download_and_install command without any pre-configured scope.",
+          "description": "Enables the notify command without any pre-configured scope.",
           "type": "string",
-          "enum": ["updater:deny-download-and-install"]
+          "const": "notification:allow-notify"
         },
         {
-          "description": "updater:deny-install -> Denies the install command without any pre-configured scope.",
+          "description": "Enables the permission_state command without any pre-configured scope.",
           "type": "string",
-          "enum": ["updater:deny-install"]
+          "const": "notification:allow-permission-state"
         },
         {
-          "description": "websocket:default -> Allows connecting and sending data to a WebSocket server",
+          "description": "Enables the register_action_types command without any pre-configured scope.",
           "type": "string",
-          "enum": ["websocket:default"]
+          "const": "notification:allow-register-action-types"
         },
         {
-          "description": "websocket:allow-connect -> Enables the connect command without any pre-configured scope.",
+          "description": "Enables the register_listener command without any pre-configured scope.",
           "type": "string",
-          "enum": ["websocket:allow-connect"]
+          "const": "notification:allow-register-listener"
         },
         {
-          "description": "websocket:allow-send -> Enables the send command without any pre-configured scope.",
+          "description": "Enables the remove_active command without any pre-configured scope.",
           "type": "string",
-          "enum": ["websocket:allow-send"]
+          "const": "notification:allow-remove-active"
         },
         {
-          "description": "websocket:deny-connect -> Denies the connect command without any pre-configured scope.",
+          "description": "Enables the request_permission command without any pre-configured scope.",
           "type": "string",
-          "enum": ["websocket:deny-connect"]
+          "const": "notification:allow-request-permission"
         },
         {
-          "description": "websocket:deny-send -> Denies the send command without any pre-configured scope.",
+          "description": "Enables the show command without any pre-configured scope.",
           "type": "string",
-          "enum": ["websocket:deny-send"]
+          "const": "notification:allow-show"
         },
         {
-          "description": "window-state:default -> This permission set configures what kind of\noperations are available from the window state plugin.\n\n#### Granted Permissions\n\nAll operations are enabled by default.\n\n",
+          "description": "Denies the batch command without any pre-configured scope.",
           "type": "string",
-          "enum": ["window-state:default"]
+          "const": "notification:deny-batch"
         },
         {
-          "description": "window-state:allow-filename -> Enables the filename command without any pre-configured scope.",
+          "description": "Denies the cancel command without any pre-configured scope.",
           "type": "string",
-          "enum": ["window-state:allow-filename"]
+          "const": "notification:deny-cancel"
         },
         {
-          "description": "window-state:allow-restore-state -> Enables the restore_state command without any pre-configured scope.",
+          "description": "Denies the check_permissions command without any pre-configured scope.",
           "type": "string",
-          "enum": ["window-state:allow-restore-state"]
+          "const": "notification:deny-check-permissions"
         },
         {
-          "description": "window-state:allow-save-window-state -> Enables the save_window_state command without any pre-configured scope.",
+          "description": "Denies the create_channel command without any pre-configured scope.",
           "type": "string",
-          "enum": ["window-state:allow-save-window-state"]
+          "const": "notification:deny-create-channel"
         },
         {
-          "description": "window-state:deny-filename -> Denies the filename command without any pre-configured scope.",
+          "description": "Denies the delete_channel command without any pre-configured scope.",
           "type": "string",
-          "enum": ["window-state:deny-filename"]
+          "const": "notification:deny-delete-channel"
         },
         {
-          "description": "window-state:deny-restore-state -> Denies the restore_state command without any pre-configured scope.",
+          "description": "Denies the get_active command without any pre-configured scope.",
           "type": "string",
-          "enum": ["window-state:deny-restore-state"]
+          "const": "notification:deny-get-active"
         },
         {
-          "description": "window-state:deny-save-window-state -> Denies the save_window_state command without any pre-configured scope.",
+          "description": "Denies the get_pending command without any pre-configured scope.",
           "type": "string",
-          "enum": ["window-state:deny-save-window-state"]
+          "const": "notification:deny-get-pending"
+        },
+        {
+          "description": "Denies the is_permission_granted command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-is-permission-granted"
+        },
+        {
+          "description": "Denies the list_channels command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-list-channels"
+        },
+        {
+          "description": "Denies the notify command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-notify"
+        },
+        {
+          "description": "Denies the permission_state command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-permission-state"
+        },
+        {
+          "description": "Denies the register_action_types command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-register-action-types"
+        },
+        {
+          "description": "Denies the register_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-register-listener"
+        },
+        {
+          "description": "Denies the remove_active command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-remove-active"
+        },
+        {
+          "description": "Denies the request_permission command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-request-permission"
+        },
+        {
+          "description": "Denies the show command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-show"
+        },
+        {
+          "description": "This permission set configures which\noperating system information are available\nto gather from the frontend.\n\n#### Granted Permissions\n\nAll information except the host name are available.\n\n",
+          "type": "string",
+          "const": "os:default"
+        },
+        {
+          "description": "Enables the arch command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:allow-arch"
+        },
+        {
+          "description": "Enables the exe_extension command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:allow-exe-extension"
+        },
+        {
+          "description": "Enables the family command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:allow-family"
+        },
+        {
+          "description": "Enables the hostname command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:allow-hostname"
+        },
+        {
+          "description": "Enables the locale command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:allow-locale"
+        },
+        {
+          "description": "Enables the os_type command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:allow-os-type"
+        },
+        {
+          "description": "Enables the platform command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:allow-platform"
+        },
+        {
+          "description": "Enables the version command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:allow-version"
+        },
+        {
+          "description": "Denies the arch command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:deny-arch"
+        },
+        {
+          "description": "Denies the exe_extension command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:deny-exe-extension"
+        },
+        {
+          "description": "Denies the family command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:deny-family"
+        },
+        {
+          "description": "Denies the hostname command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:deny-hostname"
+        },
+        {
+          "description": "Denies the locale command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:deny-locale"
+        },
+        {
+          "description": "Denies the os_type command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:deny-os-type"
+        },
+        {
+          "description": "Denies the platform command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:deny-platform"
+        },
+        {
+          "description": "Denies the version command without any pre-configured scope.",
+          "type": "string",
+          "const": "os:deny-version"
+        },
+        {
+          "description": "This permission set configures which\nprocess feeatures are by default exposed.\n\n#### Granted Permissions\n\nThis enables to quit via `allow-exit` and restart via `allow-restart`\nthe application.\n",
+          "type": "string",
+          "const": "process:default"
+        },
+        {
+          "description": "Enables the exit command without any pre-configured scope.",
+          "type": "string",
+          "const": "process:allow-exit"
+        },
+        {
+          "description": "Enables the restart command without any pre-configured scope.",
+          "type": "string",
+          "const": "process:allow-restart"
+        },
+        {
+          "description": "Denies the exit command without any pre-configured scope.",
+          "type": "string",
+          "const": "process:deny-exit"
+        },
+        {
+          "description": "Denies the restart command without any pre-configured scope.",
+          "type": "string",
+          "const": "process:deny-restart"
+        },
+        {
+          "description": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality without any specific\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n",
+          "type": "string",
+          "const": "shell:default"
+        },
+        {
+          "description": "Enables the execute command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:allow-execute"
+        },
+        {
+          "description": "Enables the kill command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:allow-kill"
+        },
+        {
+          "description": "Enables the open command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:allow-open"
+        },
+        {
+          "description": "Enables the spawn command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:allow-spawn"
+        },
+        {
+          "description": "Enables the stdin_write command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:allow-stdin-write"
+        },
+        {
+          "description": "Denies the execute command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:deny-execute"
+        },
+        {
+          "description": "Denies the kill command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:deny-kill"
+        },
+        {
+          "description": "Denies the open command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:deny-open"
+        },
+        {
+          "description": "Denies the spawn command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:deny-spawn"
+        },
+        {
+          "description": "Denies the stdin_write command without any pre-configured scope.",
+          "type": "string",
+          "const": "shell:deny-stdin-write"
+        },
+        {
+          "description": "This permission set configures which kind of\nupdater functions are exposed to the frontend.\n\n#### Granted Permissions\n\nThe full workflow from checking for updates to installing them\nis enabled.\n\n",
+          "type": "string",
+          "const": "updater:default"
+        },
+        {
+          "description": "Enables the check command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-check"
+        },
+        {
+          "description": "Enables the download command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-download"
+        },
+        {
+          "description": "Enables the download_and_install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-download-and-install"
+        },
+        {
+          "description": "Enables the install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:allow-install"
+        },
+        {
+          "description": "Denies the check command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-check"
+        },
+        {
+          "description": "Denies the download command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-download"
+        },
+        {
+          "description": "Denies the download_and_install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-download-and-install"
+        },
+        {
+          "description": "Denies the install command without any pre-configured scope.",
+          "type": "string",
+          "const": "updater:deny-install"
+        },
+        {
+          "description": "Allows connecting and sending data to a WebSocket server",
+          "type": "string",
+          "const": "websocket:default"
+        },
+        {
+          "description": "Enables the connect command without any pre-configured scope.",
+          "type": "string",
+          "const": "websocket:allow-connect"
+        },
+        {
+          "description": "Enables the send command without any pre-configured scope.",
+          "type": "string",
+          "const": "websocket:allow-send"
+        },
+        {
+          "description": "Denies the connect command without any pre-configured scope.",
+          "type": "string",
+          "const": "websocket:deny-connect"
+        },
+        {
+          "description": "Denies the send command without any pre-configured scope.",
+          "type": "string",
+          "const": "websocket:deny-send"
+        },
+        {
+          "description": "This permission set configures what kind of\noperations are available from the window state plugin.\n\n#### Granted Permissions\n\nAll operations are enabled by default.\n\n",
+          "type": "string",
+          "const": "window-state:default"
+        },
+        {
+          "description": "Enables the filename command without any pre-configured scope.",
+          "type": "string",
+          "const": "window-state:allow-filename"
+        },
+        {
+          "description": "Enables the restore_state command without any pre-configured scope.",
+          "type": "string",
+          "const": "window-state:allow-restore-state"
+        },
+        {
+          "description": "Enables the save_window_state command without any pre-configured scope.",
+          "type": "string",
+          "const": "window-state:allow-save-window-state"
+        },
+        {
+          "description": "Denies the filename command without any pre-configured scope.",
+          "type": "string",
+          "const": "window-state:deny-filename"
+        },
+        {
+          "description": "Denies the restore_state command without any pre-configured scope.",
+          "type": "string",
+          "const": "window-state:deny-restore-state"
+        },
+        {
+          "description": "Denies the save_window_state command without any pre-configured scope.",
+          "type": "string",
+          "const": "window-state:deny-save-window-state"
         }
       ]
     },
@@ -5050,31 +5531,41 @@
         {
           "description": "MacOS.",
           "type": "string",
-          "enum": ["macOS"]
+          "enum": [
+            "macOS"
+          ]
         },
         {
           "description": "Windows.",
           "type": "string",
-          "enum": ["windows"]
+          "enum": [
+            "windows"
+          ]
         },
         {
           "description": "Linux.",
           "type": "string",
-          "enum": ["linux"]
+          "enum": [
+            "linux"
+          ]
         },
         {
           "description": "Android.",
           "type": "string",
-          "enum": ["android"]
+          "enum": [
+            "android"
+          ]
         },
         {
           "description": "iOS.",
           "type": "string",
-          "enum": ["iOS"]
+          "enum": [
+            "iOS"
+          ]
         }
       ]
     },
-    "ShellAllowedArg": {
+    "ShellScopeEntryAllowedArg": {
       "description": "A command argument allowed to be executed by the webview API.",
       "anyOf": [
         {
@@ -5084,7 +5575,9 @@
         {
           "description": "A variable that is set while calling the command from the webview API.",
           "type": "object",
-          "required": ["validator"],
+          "required": [
+            "validator"
+          ],
           "properties": {
             "raw": {
               "description": "Marks the validator as a raw regex, meaning the plugin should not make any modification at runtime.\n\nThis means the regex will not match on the entire string by default, which might be exploited if your regex allow unexpected input to be considered valid. When using this option, make sure your regex is correct.",
@@ -5100,18 +5593,18 @@
         }
       ]
     },
-    "ShellAllowedArgs": {
-      "description": "A set of command arguments allowed to be executed by the webview API.\n\nA value of `true` will allow any arguments to be passed to the command. `false` will disable all arguments. A list of [`ShellAllowedArg`] will set those arguments as the only valid arguments to be passed to the attached command configuration.",
+    "ShellScopeEntryAllowedArgs": {
+      "description": "A set of command arguments allowed to be executed by the webview API.\n\nA value of `true` will allow any arguments to be passed to the command. `false` will disable all arguments. A list of [`ShellScopeEntryAllowedArg`] will set those arguments as the only valid arguments to be passed to the attached command configuration.",
       "anyOf": [
         {
           "description": "Use a simple boolean to allow all or disable all arguments to this command configuration.",
           "type": "boolean"
         },
         {
-          "description": "A specific set of [`ShellAllowedArg`] that are valid to call for the command configuration.",
+          "description": "A specific set of [`ShellScopeEntryAllowedArg`] that are valid to call for the command configuration.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ShellAllowedArg"
+            "$ref": "#/definitions/ShellScopeEntryAllowedArg"
           }
         }
       ]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -12,7 +12,6 @@ pub fn open_settings(window: WebviewWindow, update: bool) {
   let app = window.app_handle();
   let settings_windows = app.get_webview_window(SETTINGS_WINDOW_NAME);
   if let Some(settings_windows) = settings_windows {
-    let _ = settings_windows.unminimize();
     settings_windows.show();
     settings_windows.set_focus();
     if update {
@@ -41,6 +40,14 @@ pub fn get_pin(storage: State<Pinned>) -> bool {
 #[tauri::command]
 pub fn open_devtools(window: WebviewWindow) {
   window.open_devtools();
+}
+
+#[tauri::command]
+pub fn open_overlay_devtools(window: WebviewWindow) {
+  let app = window.app_handle();
+  if let Some(main_window) = app.get_webview_window(MAIN_WINDOW_NAME) {
+    main_window.open_devtools();
+  }
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -130,12 +130,13 @@ fn apply_taskbar_visibility(app: &AppHandle, pinned: bool, hide_taskbar_when_pin
   #[cfg(target_os = "macos")]
   {
     use tauri::ActivationPolicy;
-    app.set_activation_policy(if skip_taskbar {
-      ActivationPolicy::Accessory
-    } else {
-      ActivationPolicy::Regular
-    })
-    .ok();
+    app
+      .set_activation_policy(if skip_taskbar {
+        ActivationPolicy::Accessory
+      } else {
+        ActivationPolicy::Regular
+      })
+      .ok();
   }
 }
 

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -12,6 +12,7 @@ pub fn open_settings(window: WebviewWindow, update: bool) {
   let app = window.app_handle();
   let settings_windows = app.get_webview_window(SETTINGS_WINDOW_NAME);
   if let Some(settings_windows) = settings_windows {
+    let _ = settings_windows.unminimize();
     settings_windows.show();
     settings_windows.set_focus();
     if update {
@@ -47,12 +48,18 @@ pub fn toggle_pin(window: WebviewWindow, pin: State<Pinned>, menu: State<TrayMen
   let app = window.app_handle();
   let value = !get_pin(app.state::<Pinned>());
 
-  _set_pin(value, &window, pin, menu);
+  // Always target the main overlay window so pinning from other windows
+  // (e.g., settings) does not affect those windows.
+  if let Some(main_win) = app.get_webview_window(MAIN_WINDOW_NAME) {
+    _set_pin(value, &main_win, pin, menu);
+  }
 }
 
 #[tauri::command]
 pub fn set_pin(window: WebviewWindow, pin: State<Pinned>, menu: State<TrayMenu>, value: bool) {
-  _set_pin(value, &window, pin, menu);
+  if let Some(main_win) = window.app_handle().get_webview_window(MAIN_WINDOW_NAME) {
+    _set_pin(value, &main_win, pin, menu);
+  }
 }
 
 impl Deref for Pinned {
@@ -75,8 +82,19 @@ fn _set_pin(value: bool, window: &WebviewWindow, pinned: State<Pinned>, menu: St
   // @d0nutptr cooked here
   pinned.store(value, std::sync::atomic::Ordering::Relaxed);
 
-  // let the client know
+  // emit to the main window and also broadcast to all webviews so other
+  // windows (like settings) can react to the change.
   window.emit(TRAY_TOGGLE_PIN, value).unwrap();
+
+  // Broadcast the pin change to all webviews so other
+  // windows (like settings) can react to the change.
+  let app_handle = window.app_handle();
+  if let Some(main_win) = app_handle.get_webview_window(MAIN_WINDOW_NAME) {
+    let _ = main_win.emit(TRAY_TOGGLE_PIN, value);
+  }
+  if let Some(settings_win) = app_handle.get_webview_window(SETTINGS_WINDOW_NAME) {
+    let _ = settings_win.emit(TRAY_TOGGLE_PIN, value);
+  }
 
   // invert the label for the tray
   if let Some(toggle_pin_menu_item) = menu.lock().ok().and_then(|m| m.get(TRAY_TOGGLE_PIN)) {

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -5,7 +5,7 @@ use std::{
 
 use tauri::{image::Image, menu::Menu, AppHandle, Emitter, Manager, State, WebviewWindow, Wry};
 
-use crate::{constants::*, Pinned, TrayMenu};
+use crate::{constants::*, HideTaskbarWhenPinned, Pinned, TrayMenu};
 
 #[tauri::command]
 pub fn open_settings(window: WebviewWindow, update: bool) {
@@ -51,21 +51,32 @@ pub fn open_overlay_devtools(window: WebviewWindow) {
 }
 
 #[tauri::command]
-pub fn toggle_pin(window: WebviewWindow, pin: State<Pinned>, menu: State<TrayMenu>) {
+pub fn toggle_pin(
+  window: WebviewWindow,
+  pin: State<Pinned>,
+  menu: State<TrayMenu>,
+  hide_taskbar: State<HideTaskbarWhenPinned>,
+) {
   let app = window.app_handle();
   let value = !get_pin(app.state::<Pinned>());
 
   // Always target the main overlay window so pinning from other windows
   // (e.g., settings) does not affect those windows.
   if let Some(main_win) = app.get_webview_window(MAIN_WINDOW_NAME) {
-    _set_pin(value, &main_win, pin, menu);
+    _set_pin(value, &main_win, pin, menu, hide_taskbar);
   }
 }
 
 #[tauri::command]
-pub fn set_pin(window: WebviewWindow, pin: State<Pinned>, menu: State<TrayMenu>, value: bool) {
+pub fn set_pin(
+  window: WebviewWindow,
+  pin: State<Pinned>,
+  menu: State<TrayMenu>,
+  hide_taskbar: State<HideTaskbarWhenPinned>,
+  value: bool,
+) {
   if let Some(main_win) = window.app_handle().get_webview_window(MAIN_WINDOW_NAME) {
-    _set_pin(value, &main_win, pin, menu);
+    _set_pin(value, &main_win, pin, menu, hide_taskbar);
   }
 }
 
@@ -85,7 +96,41 @@ impl Deref for TrayMenu {
   }
 }
 
-fn _set_pin(value: bool, window: &WebviewWindow, pinned: State<Pinned>, menu: State<TrayMenu>) {
+impl Deref for HideTaskbarWhenPinned {
+  type Target = AtomicBool;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+fn apply_taskbar_visibility(app: &AppHandle, pinned: bool, hide_taskbar_when_pinned: bool) {
+  let skip_taskbar = pinned && hide_taskbar_when_pinned;
+
+  if let Some(main_window) = app.get_webview_window(MAIN_WINDOW_NAME) {
+    #[cfg(target_os = "windows")]
+    main_window.set_skip_taskbar(skip_taskbar).ok();
+  }
+
+  #[cfg(target_os = "macos")]
+  {
+    use tauri::ActivationPolicy;
+    app.set_activation_policy(if skip_taskbar {
+      ActivationPolicy::Accessory
+    } else {
+      ActivationPolicy::Regular
+    })
+    .ok();
+  }
+}
+
+fn _set_pin(
+  value: bool,
+  window: &WebviewWindow,
+  pinned: State<Pinned>,
+  menu: State<TrayMenu>,
+  hide_taskbar: State<HideTaskbarWhenPinned>,
+) {
   // @d0nutptr cooked here
   pinned.store(value, std::sync::atomic::Ordering::Relaxed);
 
@@ -130,6 +175,12 @@ fn _set_pin(value: bool, window: &WebviewWindow, pinned: State<Pinned>, menu: St
 
   window.set_ignore_cursor_events(value);
 
+  apply_taskbar_visibility(
+    &window.app_handle(),
+    value,
+    hide_taskbar.load(std::sync::atomic::Ordering::Relaxed),
+  );
+
   // update the tray icon
   update_tray_icon(window.app_handle(), value);
 }
@@ -146,4 +197,23 @@ pub fn update_tray_icon(app: &AppHandle, pinned: bool) {
       tray.set_icon(Some(icon));
     }
   }
+}
+
+#[tauri::command]
+pub fn set_hide_taskbar_when_pinned(
+  window: WebviewWindow,
+  hide_taskbar_when_pinned: bool,
+  pinned: State<Pinned>,
+  hide_taskbar: State<HideTaskbarWhenPinned>,
+) {
+  hide_taskbar.store(
+    hide_taskbar_when_pinned,
+    std::sync::atomic::Ordering::Relaxed,
+  );
+
+  apply_taskbar_visibility(
+    &window.app_handle(),
+    pinned.load(std::sync::atomic::Ordering::Relaxed),
+    hide_taskbar_when_pinned,
+  );
 }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -51,6 +51,21 @@ pub fn open_overlay_devtools(window: WebviewWindow) {
 }
 
 #[tauri::command]
+pub fn simulate_error_screen(window: WebviewWindow) {
+  let app = window.app_handle();
+
+  if let Some(main_window) = app.get_webview_window(MAIN_WINDOW_NAME) {
+    let _ = main_window.eval("window.location.hash = '#/error';");
+    let _ = main_window.show();
+    let _ = main_window.set_focus();
+  }
+
+  if let Some(settings_window) = app.get_webview_window(SETTINGS_WINDOW_NAME) {
+    let _ = settings_window.hide();
+  }
+}
+
+#[tauri::command]
 pub fn toggle_pin(
   window: WebviewWindow,
   pin: State<Pinned>,

--- a/apps/desktop/src-tauri/src/constants.rs
+++ b/apps/desktop/src-tauri/src/constants.rs
@@ -25,4 +25,4 @@ pub static OVERLAYED_NORMAL_LEVEL: i32 = 8;
 /// HACK: this allows constraint of the size of the settings window
 /// because the save sate plugin will not allow use to filter windows out
 pub const SETTINGS_WINDOW_WIDTH: i32 = 600;
-pub const SETTINGS_WINDOW_HEIGHT: i32 = 400;
+pub const SETTINGS_WINDOW_HEIGHT: i32 = 480;

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -40,6 +40,8 @@ use tauri::WebviewWindow;
 
 pub struct Pinned(AtomicBool);
 
+pub struct HideTaskbarWhenPinned(AtomicBool);
+
 pub struct TrayMenu(Mutex<Menu<Wry>>);
 
 #[cfg(target_os = "macos")]
@@ -115,6 +117,7 @@ fn main() {
 
   app = app
     .manage(Pinned(AtomicBool::new(false)))
+    .manage(HideTaskbarWhenPinned(AtomicBool::new(false)))
     .setup(move |app| {
       debug!("starting app...");
       let window = app.get_webview_window(MAIN_WINDOW_NAME).unwrap();
@@ -167,6 +170,7 @@ fn main() {
       open_overlay_devtools,
       close_settings,
       open_settings,
+      set_hide_taskbar_when_pinned,
     ]);
 
   app

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -168,6 +168,7 @@ fn main() {
       set_pin,
       open_devtools,
       open_overlay_devtools,
+      simulate_error_screen,
       close_settings,
       open_settings,
       set_hide_taskbar_when_pinned,

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -99,10 +99,14 @@ fn main() {
     .plugin(tauri_plugin_shell::init())
     .plugin(tauri_plugin_os::init())
     .plugin(tauri_plugin_http::init())
-    .plugin(log_plugin_builder.build())
-    .plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
+    .plugin(log_plugin_builder.build());
+
+  #[cfg(not(debug_assertions))]
+  {
+    app = app.plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
       println!("{}, {argv:?}, {cwd}", app.package_info().name);
     }));
+  }
 
   #[cfg(target_os = "macos")]
   {
@@ -152,9 +156,6 @@ fn main() {
         width: SETTINGS_WINDOW_WIDTH,
         height: SETTINGS_WINDOW_HEIGHT,
       });
-      // Start the settings window minimized so it's available but not intrusive
-      // The `show` call from the UI will restore/unminimize it.
-      settings.minimize().ok();
 
       Ok(())
     })
@@ -163,6 +164,7 @@ fn main() {
       get_pin,
       set_pin,
       open_devtools,
+      open_overlay_devtools,
       close_settings,
       open_settings,
     ]);
@@ -181,9 +183,7 @@ fn main() {
           WEvent::CloseRequested { api, .. } => {
             if label == SETTINGS_WINDOW_NAME {
               let win = app.get_webview_window(label.as_str()).unwrap();
-              // Minimize the settings window instead of hiding/closing it when
-              // the user clicks the X so it remains available to restore.
-              win.minimize().ok();
+              win.hide().unwrap();
             }
 
             if label == MAIN_WINDOW_NAME {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -152,6 +152,9 @@ fn main() {
         width: SETTINGS_WINDOW_WIDTH,
         height: SETTINGS_WINDOW_HEIGHT,
       });
+      // Start the settings window minimized so it's available but not intrusive
+      // The `show` call from the UI will restore/unminimize it.
+      settings.minimize().ok();
 
       Ok(())
     })
@@ -168,22 +171,36 @@ fn main() {
     .build(tauri::generate_context!())
     .expect("An error occured while running the app!")
     .run(|app, event| {
-      if let tauri::RunEvent::WindowEvent {
-        event: tauri::WindowEvent::CloseRequested { api, .. },
-        label,
-        ..
-      } = event
-      {
-        if label == SETTINGS_WINDOW_NAME {
-          let win = app.get_webview_window(label.as_str()).unwrap();
-          win.hide().unwrap();
-        }
+      use tauri::WindowEvent as WEvent;
 
-        if label == MAIN_WINDOW_NAME {
-          app.save_window_state(StateFlags::POSITION | StateFlags::SIZE);
-          std::process::exit(0);
-        } else {
-          api.prevent_close();
+      if let tauri::RunEvent::WindowEvent { event: we, label, .. } = event {
+        match we {
+          WEvent::CloseRequested { api, .. } => {
+            if label == SETTINGS_WINDOW_NAME {
+              let win = app.get_webview_window(label.as_str()).unwrap();
+              // Minimize the settings window instead of hiding/closing it when
+              // the user clicks the X so it remains available to restore.
+              win.minimize().ok();
+            }
+
+            if label == MAIN_WINDOW_NAME {
+              // Save state on close
+              app.save_window_state(StateFlags::POSITION | StateFlags::SIZE);
+              std::process::exit(0);
+            } else {
+              api.prevent_close();
+            }
+          }
+
+          WEvent::Resized(_) | WEvent::Moved(_) => {
+            if label == MAIN_WINDOW_NAME {
+              // Also save state whenever the main window is moved or resized so
+              // we persist the latest bounds even if the process is terminated
+              app.save_window_state(StateFlags::POSITION | StateFlags::SIZE);
+            }
+          }
+
+          _ => {}
         }
       }
     });

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -173,7 +173,10 @@ fn main() {
     .run(|app, event| {
       use tauri::WindowEvent as WEvent;
 
-      if let tauri::RunEvent::WindowEvent { event: we, label, .. } = event {
+      if let tauri::RunEvent::WindowEvent {
+        event: we, label, ..
+      } = event
+      {
         match we {
           WEvent::CloseRequested { api, .. } => {
             if label == SETTINGS_WINDOW_NAME {

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -10,9 +10,9 @@ use anyhow::Result;
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 
 use crate::{
-  commands, toggle_pin, HideTaskbarWhenPinned, Pinned, TrayMenu, MAIN_WINDOW_NAME, OVERLAYED, SETTINGS_WINDOW_NAME,
-  TRAY_OPEN_DEVTOOLS_MAIN, TRAY_OPEN_DEVTOOLS_SETTINGS, TRAY_QUIT, TRAY_RELOAD, TRAY_SETTINGS,
-  TRAY_SHOW_APP, TRAY_TOGGLE_PIN,
+  commands, toggle_pin, HideTaskbarWhenPinned, Pinned, TrayMenu, MAIN_WINDOW_NAME, OVERLAYED,
+  SETTINGS_WINDOW_NAME, TRAY_OPEN_DEVTOOLS_MAIN, TRAY_OPEN_DEVTOOLS_SETTINGS, TRAY_QUIT,
+  TRAY_RELOAD, TRAY_SETTINGS, TRAY_SHOW_APP, TRAY_TOGGLE_PIN,
 };
 
 pub struct Tray;

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 
 use crate::{
-  commands, toggle_pin, Pinned, TrayMenu, MAIN_WINDOW_NAME, OVERLAYED, SETTINGS_WINDOW_NAME,
+  commands, toggle_pin, HideTaskbarWhenPinned, Pinned, TrayMenu, MAIN_WINDOW_NAME, OVERLAYED, SETTINGS_WINDOW_NAME,
   TRAY_OPEN_DEVTOOLS_MAIN, TRAY_OPEN_DEVTOOLS_SETTINGS, TRAY_QUIT, TRAY_RELOAD, TRAY_SETTINGS,
   TRAY_SHOW_APP, TRAY_TOGGLE_PIN,
 };
@@ -52,7 +52,12 @@ impl Tray {
       TRAY_TOGGLE_PIN => {
         let window = app.get_webview_window(MAIN_WINDOW_NAME).unwrap();
 
-        toggle_pin(window, app.state::<Pinned>(), app.state::<TrayMenu>())
+        toggle_pin(
+          window,
+          app.state::<Pinned>(),
+          app.state::<TrayMenu>(),
+          app.state::<HideTaskbarWhenPinned>(),
+        )
       }
       TRAY_SHOW_APP => {
         let window = app.get_webview_window(MAIN_WINDOW_NAME).unwrap();

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -52,7 +52,7 @@
         "transparent": true,
         "decorations": true,
         "resizable": false,
-        "visible": true,
+        "visible": false,
         "label": "settings",
         "url": "#settings",
         "title": "Overlayed - Settings",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -57,7 +57,7 @@
         "url": "#settings",
         "title": "Overlayed - Settings",
         "width": 600,
-        "height": 400
+        "height": 480
       }
     ],
     "withGlobalTauri": true,

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -52,7 +52,7 @@
         "transparent": true,
         "decorations": true,
         "resizable": false,
-        "visible": false,
+        "visible": true,
         "label": "settings",
         "url": "#settings",
         "title": "Overlayed - Settings",

--- a/apps/desktop/src-tauri/tauri.conf.unsigned.json
+++ b/apps/desktop/src-tauri/tauri.conf.unsigned.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "createUpdaterArtifacts": false
+  }
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router-dom";
 import { MainView } from "./views/main";
 import { ChannelView } from "./views/channel";
 
@@ -30,12 +30,15 @@ function App() {
   const { pin } = usePin();
   const { horizontal, setHorizontalDirection } = useAlign();
   const visibleClass = visible ? "opacity-100" : "opacity-0";
+  const location = useLocation();
+  const isSettingsWindow = location.pathname === "/settings";
 
   return (
     <div
       className={cn(
         `text-white h-screen select-none rounded-lg flex flex-col ${visibleClass}`,
-        pin ? null : "border border-zinc-600"
+        // Only show the border on the overlay (main) window when not pinned.
+        pin || isSettingsWindow ? null : "border border-zinc-600"
       )}
     >
       <NavBar

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -14,6 +14,8 @@ import { Toaster } from "./components/ui/toaster";
 import { useEffect } from "react";
 import { useSocket } from "./rpc/manager";
 import { cn } from "./utils/tw";
+import Config from "./config";
+import { invoke } from "@tauri-apps/api/core";
 
 function App() {
   useDisableWebFeatures();
@@ -22,6 +24,15 @@ function App() {
   useEffect(() => {
     const styleForLog = "font-size: 20px; color: #00dffd";
     console.log(`%cOverlayed ${window.location.hash} Window`, styleForLog);
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      const config = await Config.getConfig();
+      await invoke("set_hide_taskbar_when_pinned", {
+        hideTaskbarWhenPinned: config.hideTaskbarWhenPinned,
+      });
+    })();
   }, []);
 
   const { update } = useUpdate();

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -34,7 +34,7 @@ function App() {
   return (
     <div
       className={cn(
-        `text-white h-screen select-none rounded-lg ${visibleClass}`,
+        `text-white h-screen select-none rounded-lg flex flex-col ${visibleClass}`,
         pin ? null : "border border-zinc-600"
       )}
     >
@@ -46,10 +46,10 @@ function App() {
       />
       <Toaster />
       <Routes>
-        <Route path="/" Component={MainView} />
-        <Route path="/channel" element={<ChannelView alignDirection={horizontal} />} />
-        <Route path="/settings" element={<SettingsView update={update} />} />
-        <Route path="/error" Component={ErrorView} />
+      <Route path="/" Component={MainView} />
+      <Route path="/channel" element={<ChannelView alignDirection={horizontal} />} />
+      <Route path="/settings" element={<SettingsView update={update} />} />
+      <Route path="/error" Component={ErrorView} />
       </Routes>
     </div>
   );

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -49,10 +49,10 @@ function App() {
       />
       <Toaster />
       <Routes>
-      <Route path="/" Component={MainView} />
-      <Route path="/channel" element={<ChannelView alignDirection={horizontal} />} />
-      <Route path="/settings" element={<SettingsView update={update} />} />
-      <Route path="/error" Component={ErrorView} />
+        <Route path="/" element={<MainView />} />
+        <Route path="/channel" element={<ChannelView alignDirection={horizontal} />} />
+        <Route path="/settings" element={<SettingsView update={update} />} />
+        <Route path="/error" element={<ErrorView />} />
       </Routes>
     </div>
   );

--- a/apps/desktop/src/components/nav-bar.tsx
+++ b/apps/desktop/src/components/nav-bar.tsx
@@ -6,6 +6,7 @@ import {
   ArrowLeftToLine,
   ArrowRightToLine,
   ChevronsRightLeft,
+  X,
   type LucideIcon,
 } from "lucide-react";
 import { usePlatformInfo } from "@/hooks/use-platform-info";
@@ -13,10 +14,11 @@ import React, { useEffect } from "react";
 import Config, { type DirectionLR } from "../config";
 import { useAppStore } from "../store";
 import { useState } from "react";
-import { CHANNEL_TYPES } from "@/constants";
+import { CHANNEL_TYPES, FTUE_PIN_TRAY_TIP_KEY } from "@/constants";
 import { Metric, track } from "@/metrics";
 import { invoke } from "@tauri-apps/api/core";
 import { emit } from "@tauri-apps/api/event";
+
 const mapping = {
   left: 0,
   center: 1,
@@ -75,8 +77,27 @@ export const NavBar = ({
   const showUpdateButton = location.pathname !== "/settings" && isUpdateAvailable;
 
   const routesToShowOn = ["/channel", "/error", "/"];
-  const { canary } = usePlatformInfo();
+  const { canary, os } = usePlatformInfo();
+  const [showFtue, setShowFtue] = useState(() => !localStorage.getItem(FTUE_PIN_TRAY_TIP_KEY));
+
+  const dismissFtue = () => {
+    localStorage.setItem(FTUE_PIN_TRAY_TIP_KEY, "true");
+    setShowFtue(false);
+  };
+
   if (!routesToShowOn.includes(location.pathname)) return null;
+
+  useEffect(() => {
+    // Listen for storage changes from other windows (e.g., settings clearing FTUE key)
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === FTUE_PIN_TRAY_TIP_KEY && e.newValue === null) {
+        setShowFtue(true);
+      }
+    };
+
+    window.addEventListener("storage", handleStorageChange);
+    return () => window.removeEventListener("storage", handleStorageChange);
+  }, []);
 
   useEffect(() => {
     if (!!currentChannel && ([CHANNEL_TYPES.DM, CHANNEL_TYPES.GROUP_DM] as number[]).includes(currentChannel.type)) {
@@ -85,6 +106,40 @@ export const NavBar = ({
       setChannelName(currentChannel?.name);
     }
   }, [location.pathname, currentChannel]);
+
+  function getTrayHint(os: string): React.ReactNode {
+    if (os === "windows") {
+      return (
+        <>
+          Pinning hides this frame to only show the users in the call.
+          <br /><br />
+          Unpin or access Settings anytime via the{" "}
+          <strong className="text-white">system tray</strong>{" "}
+          icon in the near the clock in your taskbar.
+        </>
+      );
+    }
+    if (os === "macos") {
+      return (
+        <>
+          Pinning hides this frame to only show the users in the call.
+          <br /><br />
+          Unpin or access Settings anytime via the{" "}
+          <strong className="text-white">menu bar</strong>{" "}
+          icon in the top-right of your screen.
+        </>
+      );
+    }
+    return (
+      <>
+        Pinning hides this frame to only show the users in the call.
+        <br /><br />
+        Unpin or access Settings anytime via the{" "}
+        <strong className="text-white">system tray</strong> /{" "}
+        <strong className="text-white">notification area</strong> icon.
+      </>
+    );
+  }
 
   return (
     <div
@@ -138,18 +193,38 @@ export const NavBar = ({
                 }}
               />
             </button>
-            <button className="cursor-pointer" title="Enable pin">
-              <Pin
-                size={20}
-                onClick={async () => {
-                  await invoke("toggle_pin");
-                  await Config.set("pin", !pin);
-                  // track if it gets pinned
-                  track(Metric.Pin, 1);
-                  navigate("/channel");
-                }}
-              />
-            </button>
+            <div className="relative flex items-center">
+              <button className="cursor-pointer" title="Enable pin">
+                <Pin
+                  size={20}
+                  onClick={async () => {
+                    await invoke("toggle_pin");
+                    await Config.set("pin", !pin);
+                    // track if it gets pinned
+                    track(Metric.Pin, 1);
+                    navigate("/channel");
+                  }}
+                />
+              </button>
+              {showFtue && (
+                <div className="absolute right-0 top-full z-50 mt-3 w-60 rounded-lg border border-zinc-700 bg-zinc-900 p-3 text-sm font-normal shadow-xl cursor-default">
+                  {/* Arrow pointing up toward the pin button */}
+                  <div className="absolute -top-3 right-0 h-0 w-0 border-x-[9px] border-b-[12px] border-x-transparent border-b-zinc-500" />
+                  <div className="flex items-start gap-2">
+                    <p className="flex-1 leading-snug text-zinc-300">
+                      {getTrayHint(os)}
+                    </p>
+                    <button
+                      onClick={dismissFtue}
+                      className="absolute right-2 top-2 shrink-0 cursor-pointer text-zinc-400 hover:text-white"
+                      title="Dismiss"
+                    >
+                      <X size={16} />
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
             <button
               className="cursor-pointer"
               title="Settings"

--- a/apps/desktop/src/components/nav-bar.tsx
+++ b/apps/desktop/src/components/nav-bar.tsx
@@ -93,7 +93,7 @@ export const NavBar = ({
       <div data-tauri-drag-region className="flex justify-between">
         <div className="flex items-center">
           <img
-            src={canary ? "/img/32x32-canary.png " : "/img/32x32.png"}
+            src={canary ? "/img/32x32-canary.png" : "/img/32x32.png"}
             alt="logo"
             data-tauri-drag-region
             className="w-8 h-8 mr-2"
@@ -122,7 +122,10 @@ export const NavBar = ({
                 />
               </button>
             )}
-            <button className="cursor-pointer" title={horizontalAlignments[currentAlignment]?.name + "-aligned. Click to toggle."}>
+            <button
+              className="cursor-pointer"
+              title={horizontalAlignments[currentAlignment]?.name + "-aligned. Click to toggle."}
+            >
               <IconComponent
                 size={20}
                 onClick={async () => {

--- a/apps/desktop/src/components/nav-bar.tsx
+++ b/apps/desktop/src/components/nav-bar.tsx
@@ -16,6 +16,7 @@ import { useState } from "react";
 import { CHANNEL_TYPES } from "@/constants";
 import { Metric, track } from "@/metrics";
 import { invoke } from "@tauri-apps/api/core";
+import { emit } from "@tauri-apps/api/event";
 const mapping = {
   left: 0,
   center: 1,
@@ -63,6 +64,11 @@ export const NavBar = ({
 
   const [channelName, setChannelName] = useState<string>();
   const [currentAlignment, setCurrentAlignment] = useState(mapping[alignDirection]);
+
+  // keep local currentAlignment in sync when the prop changes (e.g., loaded from config)
+  useEffect(() => {
+    setCurrentAlignment(mapping[alignDirection] ?? mapping.right);
+  }, [alignDirection]);
 
   const opacity = pin && location.pathname === "/channel" ? "opacity-0" : "opacity-100";
   const IconComponent = horizontalAlignments[currentAlignment]?.icon || ArrowLeftToLine;
@@ -122,8 +128,10 @@ export const NavBar = ({
                 onClick={async () => {
                   const newAlignment = (currentAlignment + 1) % horizontalAlignments.length;
                   setCurrentAlignment(newAlignment);
-                  setAlignDirection(horizontalAlignments[newAlignment]?.direction || "center");
-                  await Config.set("horizontal", horizontalAlignments[newAlignment]?.direction || "center");
+                  const dir = horizontalAlignments[newAlignment]?.direction || "center";
+                  setAlignDirection(dir);
+                  await Config.set("horizontal", dir);
+                  await emit("config_update", await Config.getConfig());
                 }}
               />
             </button>

--- a/apps/desktop/src/components/nav-bar.tsx
+++ b/apps/desktop/src/components/nav-bar.tsx
@@ -110,7 +110,7 @@ export const NavBar = ({
         {location.pathname !== "/settings" && (
           <div className="hidden gap-4 md:flex">
             {!canary && showUpdateButton && (
-              <button>
+              <button className="cursor-pointer">
                 <Download
                   className="text-green-500"
                   size={20}
@@ -122,7 +122,7 @@ export const NavBar = ({
                 />
               </button>
             )}
-            <button title={horizontalAlignments[currentAlignment]?.name + "-aligned. Click to toggle."}>
+            <button className="cursor-pointer" title={horizontalAlignments[currentAlignment]?.name + "-aligned. Click to toggle."}>
               <IconComponent
                 size={20}
                 onClick={async () => {
@@ -135,7 +135,7 @@ export const NavBar = ({
                 }}
               />
             </button>
-            <button title="Enable pin">
+            <button className="cursor-pointer" title="Enable pin">
               <Pin
                 size={20}
                 onClick={async () => {
@@ -148,6 +148,7 @@ export const NavBar = ({
               />
             </button>
             <button
+              className="cursor-pointer"
               title="Settings"
               onClick={() => {
                 invoke("open_settings", { update: false });

--- a/apps/desktop/src/components/nav-bar.tsx
+++ b/apps/desktop/src/components/nav-bar.tsx
@@ -112,10 +112,10 @@ export const NavBar = ({
       return (
         <>
           Pinning hides this frame to only show the users in the call.
-          <br /><br />
-          Unpin or access Settings anytime via the{" "}
-          <strong className="text-white">system tray</strong>{" "}
-          icon in the near the clock in your taskbar.
+          <br />
+          <br />
+          Unpin or access Settings anytime via the <strong className="text-white">system tray</strong> icon in the near
+          the clock in your taskbar.
         </>
       );
     }
@@ -123,19 +123,19 @@ export const NavBar = ({
       return (
         <>
           Pinning hides this frame to only show the users in the call.
-          <br /><br />
-          Unpin or access Settings anytime via the{" "}
-          <strong className="text-white">menu bar</strong>{" "}
-          icon in the top-right of your screen.
+          <br />
+          <br />
+          Unpin or access Settings anytime via the <strong className="text-white">menu bar</strong> icon in the
+          top-right of your screen.
         </>
       );
     }
     return (
       <>
         Pinning hides this frame to only show the users in the call.
-        <br /><br />
-        Unpin or access Settings anytime via the{" "}
-        <strong className="text-white">system tray</strong> /{" "}
+        <br />
+        <br />
+        Unpin or access Settings anytime via the <strong className="text-white">system tray</strong> /{" "}
         <strong className="text-white">notification area</strong> icon.
       </>
     );
@@ -211,9 +211,7 @@ export const NavBar = ({
                   {/* Arrow pointing up toward the pin button */}
                   <div className="absolute -top-3 right-0 h-0 w-0 border-x-[9px] border-b-[12px] border-x-transparent border-b-zinc-500" />
                   <div className="flex items-start gap-2">
-                    <p className="flex-1 leading-snug text-zinc-300">
-                      {getTrayHint(os)}
-                    </p>
+                    <p className="flex-1 leading-snug text-zinc-300">{getTrayHint(os)}</p>
                     <button
                       onClick={dismissFtue}
                       className="absolute right-2 top-2 shrink-0 cursor-pointer text-zinc-400 hover:text-white"

--- a/apps/desktop/src/components/nav-bar.tsx
+++ b/apps/desktop/src/components/nav-bar.tsx
@@ -62,7 +62,7 @@ export const NavBar = ({
 }) => {
   const location = useLocation();
   const navigate = useNavigate();
-  const { currentChannel } = useAppStore();
+  const { currentChannel, me } = useAppStore();
 
   const [channelName, setChannelName] = useState<string>();
   const [currentAlignment, setCurrentAlignment] = useState(mapping[alignDirection]);
@@ -206,7 +206,7 @@ export const NavBar = ({
                   }}
                 />
               </button>
-              {showFtue && (
+              {showFtue && !!me && (
                 <div className="absolute right-0 top-full z-50 mt-3 w-60 rounded-lg border border-zinc-700 bg-zinc-900 p-3 text-sm font-normal shadow-xl cursor-default">
                   {/* Arrow pointing up toward the pin button */}
                   <div className="absolute -top-3 right-0 h-0 w-0 border-x-[9px] border-b-[12px] border-x-transparent border-b-zinc-500" />

--- a/apps/desktop/src/components/ui/slider.tsx
+++ b/apps/desktop/src/components/ui/slider.tsx
@@ -15,7 +15,7 @@ const Slider = React.forwardRef<
     <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
       <SliderPrimitive.Range className="absolute h-full bg-primary" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-grab active:cursor-grabbing" />
   </SliderPrimitive.Root>
 ));
 Slider.displayName = SliderPrimitive.Root.displayName;

--- a/apps/desktop/src/components/ui/tabs.tsx
+++ b/apps/desktop/src/components/ui/tabs.tsx
@@ -27,7 +27,11 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-zinc-700 data-[state=active]:text-foreground data-[state=active]:shadow-xs",
+      "inline-flex items-center justify-center whitespace-nowrap",
+      "rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all",
+      "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "cursor-pointer disabled:pointer-events-none disabled:opacity-50",
+      "data-[state=active]:bg-zinc-700 data-[state=active]:text-foreground data-[state=active]:shadow-xs",
       className
     )}
     {...props}

--- a/apps/desktop/src/components/user.tsx
+++ b/apps/desktop/src/components/user.tsx
@@ -1,16 +1,20 @@
-import type { DirectionLR } from "@/config";
+import type { DirectionLR, OpacityTarget } from "@/config";
+import { useConfigValue } from "@/hooks/use-config-value";
 import type { OverlayedUser } from "../types";
 import { HeadphonesOff } from "./icons/headphones-off";
 import { MicOff } from "./icons/mic-off";
+import { cn } from "@/utils/tw";
 
 export const User = ({
   item,
   alignDirection,
   opacity,
+  opacityTarget,
 }: {
   item: OverlayedUser;
   alignDirection: DirectionLR;
   opacity: number;
+  opacityTarget: OpacityTarget;
 }) => {
   const { id, selfMuted, selfDeafened, talking, muted, deafened, avatarHash } = item;
 
@@ -20,7 +24,13 @@ export const User = ({
   const mutedClass = selfMuted || muted ? "text-zinc-400" : "";
   const opacityStyle = talking ? "100%" : `${opacity}%`;
 
-  // TODO: use tw merge so this looks better i guess
+  const { value: maxUsernameLength } = useConfigValue("maxUsernameLength");
+
+  const displayName = (() => {
+    const name = item.username ?? "";
+    if (!maxUsernameLength || name.length <= maxUsernameLength) return name;
+    return name.slice(0, Math.max(0, maxUsernameLength)) + "…";
+  })();
 
   function renderCheeseMicIcon() {
     let icon = null;
@@ -45,9 +55,11 @@ export const User = ({
 
     return (
       <div
-        className={`absolute left-[12px] bottom-[-8px] pr-[4px] py-[2px] min-w-[24px] h-[24px] ${anyState ? "bg-black/80" : "bg-transparent"} rounded-full ${
+        className={cn(
+          "absolute left-3 -bottom-2 pr-1 py-0.5 min-w-6 h-6 rounded-full",
+          anyState ? "bg-black/80" : "bg-transparent",
           alignDirection == "center" ? "flex" : "md:hidden"
-        }`}
+        )}
       >
         {icon}
       </div>
@@ -56,10 +68,11 @@ export const User = ({
 
   return (
     <div
-      className={`flex gap-2 py-1 p-2 justify-start items-center transition-opacity ${
+      className={cn(
+        "flex gap-2 py-1 p-2 justify-start items-center transition-opacity",
         alignDirection == "right" ? "flex-row-reverse" : "flex-row"
-      }`}
-      style={{ opacity: opacityStyle }}
+      )}
+      style={opacityTarget === "all" ? { opacity: opacityStyle } : undefined}
     >
       <div className={`pointer-events-none relative rounded-full border-2 ${talkingClass}`}>
         <img
@@ -80,11 +93,14 @@ export const User = ({
 
       {/* This is the normal list */}
       <div
-        className={`max-w-[calc(100%_-_50px)] md:flex hidden pointer-events-none items-center rounded-md bg-zinc-800 ${mutedClass} p-1 pl-2 pr-2 ${
-          alignDirection == "center" ? "hidden md:hidden" : ""
-        }`}
+        className={cn(
+          "max-w-[calc(100%-50px)] md:flex hidden pointer-events-none items-center rounded-md p-1 pl-2 pr-2",
+          mutedClass,
+          alignDirection == "center" ? "hidden md:hidden" : undefined
+        )}
+        style={{ backgroundColor: `rgba(40, 40, 40, ${opacityTarget === "username-box" ? opacity / 100 : 1})` }}
       >
-        <span className="truncate text-ellipsis">{item.username}</span>
+        <span className="truncate text-ellipsis">{displayName}</span>
         <div className="flex">
           {(selfMuted || muted) && <MicOff className={muted ? "fill-red-600" : "fill-current"} />}
           {(selfDeafened || deafened) && <HeadphonesOff className={deafened ? "fill-red-600" : "fill-current"} />}

--- a/apps/desktop/src/components/user.tsx
+++ b/apps/desktop/src/components/user.tsx
@@ -26,7 +26,12 @@ export const User = ({
   const mutedClass = selfMuted || muted ? "text-zinc-400" : "";
   const opacityStyle = talking ? "100%" : `${opacity}%`;
   const scaleFactor = (userScale ?? 100) / 100;
-  const transformOrigin = alignDirection === "left" ? "left center" : alignDirection === "right" ? "right center" : "center center";
+  let transformOrigin = "center center";
+  if (alignDirection === "left") {
+    transformOrigin = "left center";
+  } else if (alignDirection === "right") {
+    transformOrigin = "right center";
+  }
 
   const { value: maxUsernameLength } = useConfigValue("maxUsernameLength");
 
@@ -62,7 +67,7 @@ export const User = ({
         className={cn(
           "absolute left-3 -bottom-2 pr-1 py-0.5 min-w-6 h-6 rounded-full",
           anyState ? "bg-black/80" : "bg-transparent",
-          alignDirection == "center" ? "flex" : "md:hidden"
+          alignDirection === "center" ? "flex" : "md:hidden"
         )}
       >
         {icon}
@@ -105,7 +110,7 @@ export const User = ({
         className={cn(
           "max-w-[calc(100%-50px)] md:flex hidden pointer-events-none items-center rounded-md p-1 pl-2 pr-2",
           mutedClass,
-          alignDirection == "center" ? "hidden md:hidden" : undefined
+          alignDirection === "center" ? "hidden md:hidden" : undefined
         )}
         style={{ backgroundColor: `rgba(40, 40, 40, ${opacityTarget === "username-box" ? opacity / 100 : 1})` }}
       >

--- a/apps/desktop/src/components/user.tsx
+++ b/apps/desktop/src/components/user.tsx
@@ -10,11 +10,13 @@ export const User = ({
   alignDirection,
   opacity,
   opacityTarget,
+  userScale,
 }: {
   item: OverlayedUser;
   alignDirection: DirectionLR;
   opacity: number;
   opacityTarget: OpacityTarget;
+  userScale: number;
 }) => {
   const { id, selfMuted, selfDeafened, talking, muted, deafened, avatarHash } = item;
 
@@ -23,6 +25,8 @@ export const User = ({
   const talkingClass = talking ? "border-green-500" : "border-zinc-800";
   const mutedClass = selfMuted || muted ? "text-zinc-400" : "";
   const opacityStyle = talking ? "100%" : `${opacity}%`;
+  const scaleFactor = (userScale ?? 100) / 100;
+  const transformOrigin = alignDirection === "left" ? "left center" : alignDirection === "right" ? "right center" : "center center";
 
   const { value: maxUsernameLength } = useConfigValue("maxUsernameLength");
 
@@ -72,7 +76,12 @@ export const User = ({
         "flex gap-2 py-1 p-2 justify-start items-center transition-opacity",
         alignDirection == "right" ? "flex-row-reverse" : "flex-row"
       )}
-      style={opacityTarget === "all" ? { opacity: opacityStyle } : undefined}
+      style={{
+        ...(opacityTarget === "all" ? { opacity: opacityStyle } : {}),
+        transform: scaleFactor !== 1 ? `scale(${scaleFactor})` : undefined,
+        transformOrigin: scaleFactor !== 1 ? transformOrigin : undefined,
+        willChange: scaleFactor !== 1 ? "transform" : undefined,
+      }}
     >
       <div className={`pointer-events-none relative rounded-full border-2 ${talkingClass}`}>
         <img

--- a/apps/desktop/src/config.ts
+++ b/apps/desktop/src/config.ts
@@ -22,6 +22,7 @@ export interface OverlayedConfig {
   opacityTarget: OpacityTarget;
   maxUsernameLength: number;
   userScale: number;
+  hideTaskbarWhenPinned: boolean;
 }
 
 export type OverlayedConfigKey = keyof OverlayedConfig;
@@ -39,6 +40,7 @@ export const DEFAULT_OVERLAYED_CONFIG: OverlayedConfig = {
   opacityTarget: "all",
   maxUsernameLength: 40,
   userScale: 100,
+  hideTaskbarWhenPinned: false,
 };
 
 const CONFIG_FILE_NAME = "config.json";

--- a/apps/desktop/src/config.ts
+++ b/apps/desktop/src/config.ts
@@ -21,6 +21,7 @@ export interface OverlayedConfig {
   opacity: number;
   opacityTarget: OpacityTarget;
   maxUsernameLength: number;
+  userScale: number;
 }
 
 export type OverlayedConfigKey = keyof OverlayedConfig;
@@ -37,6 +38,7 @@ export const DEFAULT_OVERLAYED_CONFIG: OverlayedConfig = {
   opacity: 100,
   opacityTarget: "all",
   maxUsernameLength: 40,
+  userScale: 100,
 };
 
 const CONFIG_FILE_NAME = "config.json";

--- a/apps/desktop/src/config.ts
+++ b/apps/desktop/src/config.ts
@@ -5,6 +5,8 @@ import * as Sentry from "@sentry/react";
 export type DirectionLR = "left" | "right" | "center";
 export type DirectionTB = "top" | "bottom";
 
+export type OpacityTarget = "all" | "username-box";
+
 // TODO: this is hard to use we zzz
 // NOTE: how can i handle versions updates where i add new keys
 // NOTE: this looks cool https://github.com/harshkhandeparkar/tauri-settings/issues
@@ -17,6 +19,8 @@ export interface OverlayedConfig {
   showOnlyTalkingUsers: boolean;
   showOwnUser: boolean;
   opacity: number;
+  opacityTarget: OpacityTarget;
+  maxUsernameLength: number;
 }
 
 export type OverlayedConfigKey = keyof OverlayedConfig;
@@ -31,6 +35,8 @@ export const DEFAULT_OVERLAYED_CONFIG: OverlayedConfig = {
   showOnlyTalkingUsers: false,
   showOwnUser: true,
   opacity: 100,
+  opacityTarget: "all",
+  maxUsernameLength: 40,
 };
 
 const CONFIG_FILE_NAME = "config.json";
@@ -94,10 +100,19 @@ export class Config {
   }
 
   async set<K extends keyof OverlayedConfig>(key: K, value: OverlayedConfig[K]): Promise<void> {
-    await this.load();
+    // Always re-load the on-disk config to avoid races where multiple
+    // concurrent callers might overwrite recent changes. This ensures we
+    // merge against the latest file contents before writing.
+    try {
+      const config = await readTextFile(CONFIG_FILE_NAME, { baseDir: BaseDirectory.AppConfig });
+      this.config = JSON.parse(config);
+    } catch (e: unknown) {
+      // ignore and fall back to current in-memory or defaults
+      this.config = { ...DEFAULT_OVERLAYED_CONFIG, ...this.config };
+    }
 
     this.config[key] = value;
-    this.save();
+    await this.save();
   }
 
   async save() {

--- a/apps/desktop/src/constants.ts
+++ b/apps/desktop/src/constants.ts
@@ -22,3 +22,5 @@ export const CHANNEL_TYPES = {
   GUILD_FORUM: 15,
   GUILD_MEDIA: 16,
 } as const;
+
+export const FTUE_PIN_TRAY_TIP_KEY = "overlayed:ftue:pin-tray-tip-shown";

--- a/apps/desktop/src/hooks/use-align.ts
+++ b/apps/desktop/src/hooks/use-align.ts
@@ -1,10 +1,36 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { type DirectionLR, type DirectionTB } from "../config";
+import Config, { DEFAULT_OVERLAYED_CONFIG, type OverlayedConfig } from "@/config";
+import { listen } from "@tauri-apps/api/event";
 
 // TODO: make it update automatically when the window moves
 export const useAlign = () => {
-  const [horizontal, setHorizontalDirection] = useState<DirectionLR>("right");
-  const [vertical, setVerticalDirection] = useState<DirectionTB>("bottom");
+  const [horizontal, setHorizontalDirection] = useState<DirectionLR>(DEFAULT_OVERLAYED_CONFIG.horizontal);
+  const [vertical, setVerticalDirection] = useState<DirectionTB>(DEFAULT_OVERLAYED_CONFIG.vertical);
+
+  useEffect(() => {
+    const init = async () => {
+      const saved = await Config.get("horizontal");
+      setHorizontalDirection(saved as DirectionLR);
+
+      const savedV = await Config.get("vertical");
+      setVerticalDirection(savedV as DirectionTB);
+    };
+
+    init();
+
+    const listenFn = listen<OverlayedConfig>("config_update", event => {
+      const { payload } = event;
+      if (payload.horizontal) setHorizontalDirection(payload.horizontal as DirectionLR);
+      if (payload.vertical) setVerticalDirection(payload.vertical as DirectionTB);
+    });
+
+    return () => {
+      (async () => {
+        await listenFn;
+      })();
+    };
+  }, []);
 
   return { horizontal, vertical, setHorizontalDirection, setVerticalDirection };
 };

--- a/apps/desktop/src/rpc/manager.ts
+++ b/apps/desktop/src/rpc/manager.ts
@@ -131,7 +131,16 @@ class SocketManager {
     // subscribe to local storage events to see if we need to move the user to the auth page
     window.addEventListener("storage", e => {
       if (e.key === "discord_access_token" && !e.newValue) {
+        this.store.setMe(null);
+        this.store.setCurrentChannel(null);
+        this.store.clearUsers();
         this.navigate("/");
+      }
+
+      if (e.key === "user_data" && !e.newValue) {
+        this.store.setMe(null);
+        this.store.setCurrentChannel(null);
+        this.store.clearUsers();
       }
     });
   }

--- a/apps/desktop/src/rpc/manager.ts
+++ b/apps/desktop/src/rpc/manager.ts
@@ -52,6 +52,15 @@ class UserdataStore {
     this.store.removeItem(this.keys.accessToken);
     this.store.removeItem(this.keys.accessTokenExpiry);
   }
+
+  removeUserdata() {
+    this.store.removeItem(this.keys.userData);
+  }
+
+  clearAuth() {
+    this.removeAccessToken();
+    this.removeUserdata();
+  }
 }
 
 /**
@@ -337,14 +346,23 @@ class SocketManager {
     // console.log(payload);
     // we are ready to do things cause we are fully authed
     if (payload.cmd === RPCCommand.AUTHENTICATE && payload.evt === RPCEvent.ERROR) {
-      // they have a token from the old client id
-      if (payload.data.code === RPCErrors.INVALID_CLIENTID) {
-        this.userdataStore.removeAccessToken();
-      }
+      // These are recoverable auth issues (e.g. expired/revoked token),
+      // so clear auth state and send the user back to the reauth screen.
+      const shouldReauth = [
+        RPCErrors.INVALID_CLIENTID,
+        RPCErrors.INVALID_TOKEN,
+        RPCErrors.INVALID_USER,
+        RPCErrors.OAUTH2_ERROR,
+      ].includes(payload.data.code);
 
-      // they have an invalid token
-      if (payload.data.code === RPCErrors.INVALID_TOKEN) {
-        this.userdataStore.removeAccessToken();
+      if (shouldReauth) {
+        this.userdataStore.clearAuth();
+        this.store.setMe(null);
+        this.store.setCurrentChannel(null);
+        this.store.clearUsers();
+        this.navigate("/");
+        track(Metric.DiscordAuthed, 0);
+        return;
       }
 
       this.store.pushError(payload.data.message);

--- a/apps/desktop/src/views/channel.tsx
+++ b/apps/desktop/src/views/channel.tsx
@@ -11,6 +11,7 @@ export const ChannelView = ({ alignDirection }: { alignDirection: DirectionLR })
   const { value: showOwnUser } = useConfigValue("showOwnUser");
   const { value: opacity } = useConfigValue("opacity");
   const { value: opacityTarget } = useConfigValue("opacityTarget");
+  const { value: userScale } = useConfigValue("userScale");
   const { value: vertical } = useConfigValue("vertical");
 
   const allUsers = Object.entries(users);
@@ -27,18 +28,27 @@ export const ChannelView = ({ alignDirection }: { alignDirection: DirectionLR })
     <div className="h-full">
       <div
         className={cn(
-          "py-2 h-full overflow-auto",
+          "py-2 h-full",
           {
             "flex flex-wrap justify-center": alignDirection === "center",
             "flex flex-1 flex-col": alignDirection !== "center",
             "justify-end": alignDirection !== "center" && vertical === "bottom",
             "justify-start": alignDirection !== "center" && vertical !== "bottom",
+            "overflow-auto": userScale === 100,
+            "overflow-visible": userScale !== 100,
           }
         )}
         style={{ maxHeight: "100%" }}
       >
         {userList.map(([, item]) => (
-          <User key={item.id} item={item} alignDirection={alignDirection} opacity={opacity} opacityTarget={opacityTarget} />
+          <User
+            key={item.id}
+            item={item}
+            alignDirection={alignDirection}
+            opacity={opacity}
+            opacityTarget={opacityTarget}
+            userScale={userScale}
+          />
         ))}
       </div>
     </div>

--- a/apps/desktop/src/views/channel.tsx
+++ b/apps/desktop/src/views/channel.tsx
@@ -1,5 +1,6 @@
 import type { DirectionLR } from "@/config";
 import { User } from "../components/user";
+import { cn } from "@/utils/tw";
 import { useAppStore } from "../store";
 import { useConfigValue } from "@/hooks/use-config-value";
 
@@ -9,6 +10,8 @@ export const ChannelView = ({ alignDirection }: { alignDirection: DirectionLR })
   const { value: showOnlyTalkingUsers } = useConfigValue("showOnlyTalkingUsers");
   const { value: showOwnUser } = useConfigValue("showOwnUser");
   const { value: opacity } = useConfigValue("opacity");
+  const { value: opacityTarget } = useConfigValue("opacityTarget");
+  const { value: vertical } = useConfigValue("vertical");
 
   const allUsers = Object.entries(users);
   let userList = showOnlyTalkingUsers ? allUsers.filter(([, item]) => item.talking) : allUsers;
@@ -21,10 +24,21 @@ export const ChannelView = ({ alignDirection }: { alignDirection: DirectionLR })
   });
 
   return (
-    <div>
-      <div className={`py-2 ${alignDirection === "center" ? "flex flex-wrap justify-center" : ""}`}>
+    <div className="h-full">
+      <div
+        className={cn(
+          "py-2 h-full overflow-auto",
+          {
+            "flex flex-wrap justify-center": alignDirection === "center",
+            "flex flex-1 flex-col": alignDirection !== "center",
+            "justify-end": alignDirection !== "center" && vertical === "bottom",
+            "justify-start": alignDirection !== "center" && vertical !== "bottom",
+          }
+        )}
+        style={{ maxHeight: "100%" }}
+      >
         {userList.map(([, item]) => (
-          <User key={item.id} item={item} alignDirection={alignDirection} opacity={opacity} />
+          <User key={item.id} item={item} alignDirection={alignDirection} opacity={opacity} opacityTarget={opacityTarget} />
         ))}
       </div>
     </div>

--- a/apps/desktop/src/views/channel.tsx
+++ b/apps/desktop/src/views/channel.tsx
@@ -27,17 +27,14 @@ export const ChannelView = ({ alignDirection }: { alignDirection: DirectionLR })
   return (
     <div className="h-full">
       <div
-        className={cn(
-          "py-2 h-full",
-          {
-            "flex flex-wrap justify-center": alignDirection === "center",
-            "flex flex-1 flex-col": alignDirection !== "center",
-            "justify-end": alignDirection !== "center" && vertical === "bottom",
-            "justify-start": alignDirection !== "center" && vertical !== "bottom",
-            "overflow-auto": userScale === 100,
-            "overflow-visible": userScale !== 100,
-          }
-        )}
+        className={cn("py-2 h-full", {
+          "flex flex-wrap justify-center": alignDirection === "center",
+          "flex flex-1 flex-col": alignDirection !== "center",
+          "justify-end": alignDirection !== "center" && vertical === "bottom",
+          "justify-start": alignDirection !== "center" && vertical !== "bottom",
+          "overflow-auto": userScale === 100,
+          "overflow-visible": userScale !== 100,
+        })}
         style={{ maxHeight: "100%" }}
       >
         {userList.map(([, item]) => (

--- a/apps/desktop/src/views/settings/account.tsx
+++ b/apps/desktop/src/views/settings/account.tsx
@@ -17,7 +17,9 @@ import {
   DialogClose,
 } from "@/components/ui/dialog";
 import { useEffect, useState } from "react";
+import { usePin } from "@/hooks/use-pin";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Pin } from "lucide-react";
 import type { VoiceUser } from "@/types";
 import * as shell from "@tauri-apps/plugin-shell";
 
@@ -100,6 +102,7 @@ export const Account = () => {
   const [showQuitDialog, setShowQuitDialog] = useState(false);
   const [user, setUser] = useState<VoiceUser | null>(null);
   const [tokenExpires, setTokenExpires] = useState(localStorage.getItem("discord_access_token_expiry"));
+  const { pin: pinned } = usePin();
 
   // pull out the user data from localStorage
   useEffect(() => {
@@ -160,6 +163,23 @@ export const Account = () => {
         </div>
         <div className="flex flex-row gap-4 pb-4">
           <div>
+            <Button
+              size="sm"
+              variant="outline"
+              className="w-24 flex items-center justify-center"
+              onClick={async () => {
+                try {
+                  await invoke("set_pin", { value: !pinned });
+                } catch (e) {
+                  console.error("failed to set pin", e);
+                }
+              }}
+            >
+              <Pin className={pinned ? "mr-2 h-4 w-4 text-yellow-400" : "mr-2 h-4 w-4"} size={16} />
+              {pinned ? "Unpin" : "Pin"}
+            </Button>
+          </div>
+          <div>
             <Dialog
               onOpenChange={e => {
                 setShowLogoutDialog(e);
@@ -167,7 +187,7 @@ export const Account = () => {
               open={showLogoutDialog}
             >
               <DialogTrigger asChild>
-                <Button size="sm" disabled={!user?.id} className="w-[100px]">
+                <Button size="sm" disabled={!user?.id} className="w-20">
                   Logout
                 </Button>
               </DialogTrigger>
@@ -208,7 +228,7 @@ export const Account = () => {
             open={showQuitDialog}
           >
             <DialogTrigger asChild>
-              <Button size="sm" className="w-[100px]">
+              <Button size="sm" className="w-20">
                 Quit
               </Button>
             </DialogTrigger>

--- a/apps/desktop/src/views/settings/account.tsx
+++ b/apps/desktop/src/views/settings/account.tsx
@@ -26,6 +26,53 @@ import * as shell from "@tauri-apps/plugin-shell";
 
 export const Developer = () => {
   const platformInfo = usePlatformInfo();
+  const DEV_TOKEN_BACKUP_KEY = "overlayed:dev:token-backup";
+  const DEV_TOKEN_EXPIRY_BACKUP_KEY = "overlayed:dev:token-expiry-backup";
+  const DEV_USER_DATA_BACKUP_KEY = "overlayed:dev:user-data-backup";
+
+  const simulateTokenExpiryForTesting = async () => {
+    const currentToken = localStorage.getItem("discord_access_token");
+    const currentTokenExpiry = localStorage.getItem("discord_access_token_expiry");
+    const currentUserData = localStorage.getItem("user_data");
+
+    if (currentToken) {
+      localStorage.setItem(DEV_TOKEN_BACKUP_KEY, currentToken);
+    }
+    if (currentTokenExpiry) {
+      localStorage.setItem(DEV_TOKEN_EXPIRY_BACKUP_KEY, currentTokenExpiry);
+    }
+    if (currentUserData) {
+      localStorage.setItem(DEV_USER_DATA_BACKUP_KEY, currentUserData);
+    }
+
+    // Clear auth keys so the app immediately routes back to the re-auth screen.
+    localStorage.removeItem("discord_access_token");
+    localStorage.removeItem("discord_access_token_expiry");
+    localStorage.removeItem("user_data");
+
+    // Bring focus back to the main window where the auth screen is shown.
+    await invoke("close_settings");
+  };
+
+  const restoreTokenAfterTesting = () => {
+    const tokenBackup = localStorage.getItem(DEV_TOKEN_BACKUP_KEY);
+    const tokenExpiryBackup = localStorage.getItem(DEV_TOKEN_EXPIRY_BACKUP_KEY);
+    const userDataBackup = localStorage.getItem(DEV_USER_DATA_BACKUP_KEY);
+
+    if (tokenBackup) {
+      localStorage.setItem("discord_access_token", tokenBackup);
+      localStorage.removeItem(DEV_TOKEN_BACKUP_KEY);
+    }
+    if (tokenExpiryBackup) {
+      localStorage.setItem("discord_access_token_expiry", tokenExpiryBackup);
+      localStorage.removeItem(DEV_TOKEN_EXPIRY_BACKUP_KEY);
+    }
+    if (userDataBackup) {
+      localStorage.setItem("user_data", userDataBackup);
+      localStorage.removeItem(DEV_USER_DATA_BACKUP_KEY);
+    }
+  };
+
   return (
     <>
       <div className="flex flex-col gap-2">
@@ -35,18 +82,10 @@ export const Developer = () => {
             variant="outline"
             onClick={async () => {
               await invoke("open_devtools");
-            }}
-          >
-            Open Devtools
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={async () => {
               await invoke("open_overlay_devtools");
             }}
           >
-            Open Overlay Devtools
+            Open Devtools
           </Button>
           <Button
             size="sm"
@@ -57,7 +96,9 @@ export const Developer = () => {
           >
             Open Config Dir
           </Button>
-          {import.meta.env.DEV && (
+        </div>
+        {import.meta.env.DEV && (
+          <div className="flex gap-4 pb-2">
             <Button
               size="sm"
               variant="outline"
@@ -67,8 +108,29 @@ export const Developer = () => {
             >
               Reset FTUE tip
             </Button>
-          )}
-        </div>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                void simulateTokenExpiryForTesting();
+              }}
+            >
+              Expire Auth
+            </Button>
+            <Button size="sm" variant="outline" onClick={restoreTokenAfterTesting}>
+              Restore Auth
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={async () => {
+                await invoke("simulate_error_screen");
+              }}
+            >
+              Simulate Error Screen
+            </Button>
+          </div>
+        )}
       </div>
     </>
   );

--- a/apps/desktop/src/views/settings/account.tsx
+++ b/apps/desktop/src/views/settings/account.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { FTUE_PIN_TRAY_TIP_KEY } from "@/constants";
 import { exit } from "@tauri-apps/plugin-process";
 import * as dateFns from "date-fns";
 import { saveWindowState, StateFlags } from "@tauri-apps/plugin-window-state";
@@ -42,11 +43,31 @@ export const Developer = () => {
             size="sm"
             variant="outline"
             onClick={async () => {
+              await invoke("open_overlay_devtools");
+            }}
+          >
+            Open Overlay Devtools
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={async () => {
               await shell.open(platformInfo.configDir);
             }}
           >
             Open Config Dir
           </Button>
+          {import.meta.env.DEV && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                localStorage.removeItem(FTUE_PIN_TRAY_TIP_KEY);
+              }}
+            >
+              Reset FTUE tip
+            </Button>
+          )}
         </div>
       </div>
     </>
@@ -257,8 +278,8 @@ export const Account = () => {
               </form>
             </DialogContent>
           </Dialog>
-          <Developer />
         </div>
+        <Developer />
         <AppInfo />
       </div>
     </div>

--- a/apps/desktop/src/views/settings/configuration.tsx
+++ b/apps/desktop/src/views/settings/configuration.tsx
@@ -69,7 +69,7 @@ export const Configuration = () => {
 
             await emit("config_update", await Config.getConfig());
           }}
-          className="w-40 p-1 rounded border bg-zinc-800 text-white outline-none focus:ring-0"
+          className="w-40 p-1 rounded border bg-zinc-800 text-white outline-none focus:ring-0 cursor-pointer"
         >
           <option value="left" className="bg-zinc-800 text-white">Left</option>
           <option value="center" className="bg-zinc-800 text-white">Center</option>
@@ -89,7 +89,7 @@ export const Configuration = () => {
 
             await emit("config_update", await Config.getConfig());
           }}
-          className="w-40 p-1 rounded border bg-zinc-800 text-white outline-none focus:ring-0"
+          className="w-40 p-1 rounded border bg-zinc-800 text-white outline-none focus:ring-0 cursor-pointer"
         >
           <option value="top" className="bg-zinc-800 text-white">
             Top
@@ -112,7 +112,7 @@ export const Configuration = () => {
 
             await emit("config_update", await Config.getConfig());
           }}
-          className="p-1 rounded border bg-zinc-800 text-white outline-none focus:ring-0"
+          className="p-1 rounded border bg-zinc-800 text-white outline-none focus:ring-0 cursor-pointer"
         >
           <option value="all" className="bg-zinc-800 text-white">
             Everything

--- a/apps/desktop/src/views/settings/configuration.tsx
+++ b/apps/desktop/src/views/settings/configuration.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@/components/ui/input";
+import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import Config from "@/config";
 import { useConfigValue } from "@/hooks/use-config-value";
@@ -7,13 +7,17 @@ import { emit } from "@tauri-apps/api/event";
 export const Configuration = () => {
   const { value: showOnlyTalkingUsers } = useConfigValue("showOnlyTalkingUsers");
   const { value: opacity } = useConfigValue("opacity");
+  const { value: opacityTarget } = useConfigValue("opacityTarget");
+  const { value: vertical } = useConfigValue("vertical");
+  const { value: horizontal } = useConfigValue("horizontal");
+  const { value: maxUsernameLength } = useConfigValue("maxUsernameLength");
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between mt-2 h-8 mx-2">
         <label
           htmlFor="notification"
-          className="ml-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
         >
           Only show users who are speaking
         </label>
@@ -28,27 +32,117 @@ export const Configuration = () => {
           }}
         />
       </div>
-      <div className="flex items-center justify-between">
-        <label
-          htmlFor="opacity"
-          className="ml-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-        >
-          Overlay opacity
+      <div className="flex items-center justify-between h-8 mx-2">
+        <label htmlFor="maxUsernameLength" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+          Max username length
         </label>
-        <Input
-          id="opacity"
-          type="number"
-          min={1}
-          max={100}
-          value={opacity}
+        <div className="flex items-center gap-4 w-1/2">
+          <div className="flex-1">
+            <Slider
+              value={[maxUsernameLength]}
+              min={4}
+              max={60}
+              step={1}
+              onValueChange={async (val: number[]) => {
+                const newVal = val[0] ?? maxUsernameLength;
+                await Config.set("maxUsernameLength", Number(newVal));
+                await emit("config_update", await Config.getConfig());
+              }}
+            />
+          </div>
+          <div className="w-10 text-right">
+            <span className="text-sm">{maxUsernameLength}</span>
+          </div>
+        </div>
+      </div>
+      <div className="flex items-center justify-between h-8 mx-2">
+        <label htmlFor="horizontal" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+          Anchor horizontal
+        </label>
+        <select
+          id="horizontal"
+          value={horizontal}
           onChange={async event => {
-            const newOpacity = event.target.value;
-            await Config.set("opacity", Number(newOpacity));
+            const newTarget = event.target.value as "left" | "center" | "right";
+            await Config.set("horizontal", newTarget);
 
             await emit("config_update", await Config.getConfig());
           }}
-          className="w-20"
-        />
+          className="w-40 p-1 rounded border bg-zinc-800 text-white outline-none focus:ring-0"
+        >
+          <option value="left" className="bg-zinc-800 text-white">Left</option>
+          <option value="center" className="bg-zinc-800 text-white">Center</option>
+          <option value="right" className="bg-zinc-800 text-white">Right</option>
+        </select>
+      </div>
+      <div className="flex items-center justify-between h-8 mx-2">
+        <label htmlFor="vertical" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+          Anchor vertical
+        </label>
+        <select
+          id="vertical"
+          value={vertical}
+          onChange={async event => {
+            const newTarget = event.target.value as "top" | "bottom";
+            await Config.set("vertical", newTarget);
+
+            await emit("config_update", await Config.getConfig());
+          }}
+          className="w-40 p-1 rounded border bg-zinc-800 text-white outline-none focus:ring-0"
+        >
+          <option value="top" className="bg-zinc-800 text-white">
+            Top
+          </option>
+          <option value="bottom" className="bg-zinc-800 text-white">
+            Bottom
+          </option>
+        </select>
+      </div>
+      <div className="flex items-center justify-between h-8 mx-2">
+        <label htmlFor="opacityTarget" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+          Opacity target
+        </label>
+        <select
+          id="opacityTarget"
+          value={opacityTarget}
+          onChange={async event => {
+            const newTarget = event.target.value as "all" | "username-box";
+            await Config.set("opacityTarget", newTarget);
+
+            await emit("config_update", await Config.getConfig());
+          }}
+          className="p-1 rounded border bg-zinc-800 text-white outline-none focus:ring-0"
+        >
+          <option value="all" className="bg-zinc-800 text-white">
+            Everything
+          </option>
+          <option value="username-box" className="bg-zinc-800 text-white">
+            Username background only
+          </option>
+        </select>
+      </div>
+      <div className="flex items-center justify-between h-8 mx-2">
+        <label htmlFor="opacity" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+          Overlay opacity
+        </label>
+        <div className="flex items-center gap-4 w-1/2">
+          <div className="flex-1">
+            <Slider
+              value={[opacity]}
+              min={1}
+              max={100}
+              step={1}
+              onValueChange={async (val: number[]) => {
+                const newVal = val[0] ?? opacity;
+                await Config.set("opacity", Number(newVal));
+                await emit("config_update", await Config.getConfig());
+              }}
+            />
+          </div>
+          <div className="w-10 text-right">
+            <span className="text-sm">{opacity} %</span>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/views/settings/configuration.tsx
+++ b/apps/desktop/src/views/settings/configuration.tsx
@@ -34,7 +34,10 @@ export const Configuration = () => {
         />
       </div>
       <div className="flex items-center justify-between h-8 mx-2">
-        <label htmlFor="maxUsernameLength" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+        <label
+          htmlFor="maxUsernameLength"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
           Max username length
         </label>
         <div className="flex items-center gap-4 w-1/2">
@@ -57,7 +60,10 @@ export const Configuration = () => {
         </div>
       </div>
       <div className="flex items-center justify-between h-8 mx-2">
-        <label htmlFor="horizontal" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+        <label
+          htmlFor="horizontal"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
           Anchor horizontal
         </label>
         <select
@@ -71,13 +77,22 @@ export const Configuration = () => {
           }}
           className="w-40 p-1 rounded border bg-zinc-800 text-white outline-none focus:ring-0 cursor-pointer"
         >
-          <option value="left" className="bg-zinc-800 text-white">Left</option>
-          <option value="center" className="bg-zinc-800 text-white">Center</option>
-          <option value="right" className="bg-zinc-800 text-white">Right</option>
+          <option value="left" className="bg-zinc-800 text-white">
+            Left
+          </option>
+          <option value="center" className="bg-zinc-800 text-white">
+            Center
+          </option>
+          <option value="right" className="bg-zinc-800 text-white">
+            Right
+          </option>
         </select>
       </div>
       <div className="flex items-center justify-between h-8 mx-2">
-        <label htmlFor="vertical" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+        <label
+          htmlFor="vertical"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
           Anchor vertical
         </label>
         <select
@@ -100,7 +115,10 @@ export const Configuration = () => {
         </select>
       </div>
       <div className="flex items-center justify-between h-8 mx-2">
-        <label htmlFor="opacityTarget" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+        <label
+          htmlFor="opacityTarget"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
           Opacity target
         </label>
         <select
@@ -123,7 +141,10 @@ export const Configuration = () => {
         </select>
       </div>
       <div className="flex items-center justify-between h-8 mx-2">
-        <label htmlFor="opacity" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+        <label
+          htmlFor="opacity"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
           Overlay opacity
         </label>
         <div className="flex items-center gap-4 w-1/2">
@@ -146,7 +167,10 @@ export const Configuration = () => {
         </div>
       </div>
       <div className="flex items-center justify-between h-8 mx-2">
-        <label htmlFor="userScale" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+        <label
+          htmlFor="userScale"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
           Scale
         </label>
         <div className="flex items-center gap-4 w-1/2">

--- a/apps/desktop/src/views/settings/configuration.tsx
+++ b/apps/desktop/src/views/settings/configuration.tsx
@@ -11,6 +11,7 @@ export const Configuration = () => {
   const { value: vertical } = useConfigValue("vertical");
   const { value: horizontal } = useConfigValue("horizontal");
   const { value: maxUsernameLength } = useConfigValue("maxUsernameLength");
+  const { value: userScale } = useConfigValue("userScale");
 
   return (
     <div className="flex flex-col gap-2">
@@ -141,6 +142,29 @@ export const Configuration = () => {
           </div>
           <div className="w-10 text-right">
             <span className="text-sm">{opacity} %</span>
+          </div>
+        </div>
+      </div>
+      <div className="flex items-center justify-between h-8 mx-2">
+        <label htmlFor="userScale" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+          Scale
+        </label>
+        <div className="flex items-center gap-4 w-1/2">
+          <div className="flex-1">
+            <Slider
+              value={[userScale]}
+              min={50}
+              max={200}
+              step={5}
+              onValueChange={async (val: number[]) => {
+                const newVal = val[0] ?? userScale;
+                await Config.set("userScale", Number(newVal));
+                await emit("config_update", await Config.getConfig());
+              }}
+            />
+          </div>
+          <div className="w-16 text-right">
+            <span className="text-sm">{userScale} %</span>
           </div>
         </div>
       </div>

--- a/apps/desktop/src/views/settings/configuration.tsx
+++ b/apps/desktop/src/views/settings/configuration.tsx
@@ -3,6 +3,7 @@ import { Switch } from "@/components/ui/switch";
 import Config from "@/config";
 import { useConfigValue } from "@/hooks/use-config-value";
 import { emit } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
 
 export const Configuration = () => {
   const { value: showOnlyTalkingUsers } = useConfigValue("showOnlyTalkingUsers");
@@ -12,6 +13,7 @@ export const Configuration = () => {
   const { value: horizontal } = useConfigValue("horizontal");
   const { value: maxUsernameLength } = useConfigValue("maxUsernameLength");
   const { value: userScale } = useConfigValue("userScale");
+  const { value: hideTaskbarWhenPinned } = useConfigValue("hideTaskbarWhenPinned");
 
   return (
     <div className="flex flex-col gap-2">
@@ -191,6 +193,28 @@ export const Configuration = () => {
             <span className="text-sm">{userScale} %</span>
           </div>
         </div>
+      </div>
+      <div className="flex items-center justify-between h-8 mx-2">
+        <label
+          htmlFor="hideTaskbar"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
+          Hide taskbar when pinned
+        </label>
+        <Switch
+          id="hideTaskbar"
+          checked={hideTaskbarWhenPinned}
+          onCheckedChange={async () => {
+            const newBool = !hideTaskbarWhenPinned;
+            await Config.set("hideTaskbarWhenPinned", newBool);
+
+            await invoke("set_hide_taskbar_when_pinned", {
+              hideTaskbarWhenPinned: newBool,
+            });
+
+            await emit("config_update", await Config.getConfig());
+          }}
+        />
       </div>
     </div>
   );

--- a/apps/desktop/turbo.json
+++ b/apps/desktop/turbo.json
@@ -8,6 +8,7 @@
       "outputs": ["dist/**"]
     },
     "build:desktop": {},
+    "build:desktop:unsigned": {},
     "start:canary": {},
     "build:canary": {},
     "start": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "desktop": "pnpm turbo run start --filter=desktop",
     "build": "turbo run build",
     "build:desktop": "turbo run build:desktop",
+    "build:desktop:unsigned": "turbo run build:desktop:unsigned",
     "build:canary": "turbo run build:canary",
     "check:format": "turbo run check:format",
     "clean": "turbo run clean && rm -rf node_modules .turbo",


### PR DESCRIPTION
Followup on https://github.com/overlayeddev/overlayed/pull/240, closes #67 (anchoring)

- Opacity by default changes the opacity of the entire user row including the avatar, but I want it to only affect the background behind the username (I want avatars to always be fully opaque), so I added a "target" option.
- Opacity is now a slider instead (easier to use).
- Add anchor horizontal and vertical options, where horizontal maps to the existing option in the nav-bar of switching left/center/right side (but now also reflected in the config, and synced if either changes), and vertical anchor so there's now the option of having it grow upwards. If "center" is chosen for horizontal then top/bottom is ignored (I don't have a usecase for that mode so I don't know how best to integrate that if at all).
- The anchor horizontal option is now persisted and loaded properly, previously it would need to be toggled each time if you want it on the left when you open the app, pretty annoying.
- Added a Max username length limit which truncates the usernames with a `...` if too long. This makes sure the overlay will be limited on width, better to plan consistent layouts if using this with OBS for streaming. I realize resizing the window also does this to a certain extent, but I think having both is good for level of control.
- Added a Scale option, between 50% and 200%. This gives really nice control, and doing it in-app instead of in OBS after the fact or w/e means it'll render very crisp.

In followup commits:
- Cleaned up the nav-bar buttons to use the 👆 cursor
- Added a pin/unpin toggle button on the settings window's General page
- Removed 1px pin border from the settings window (it should only affect the overlay, not also the settings window)
- Made it save the overlay position/size settings immediately after change, instead of only on quit, because when dev-ing I noticed if I Ctrl+C kill it, the overlay position didn't persist. Thought that was weird.
- ~~Made the settings window start opened but minimized, made the X button not close but minimize; this gives easier access to toggling unpin (on first-time-use of the app, it's surprising and confusing if you pin and then realize "oh shit how do I unpin aaaaaaaaaa", so I think this is a better default). Users can find the settings pane via their taskbar (on Windows anyway, I don't know if this behaves weird on Mac/Linux)~~ Introduced an FTUE popup on first use which explains how pinning works instead.
- Added an option to enable hiding the taskbar/dock icon when pinned (as long as the settings window is also closed). Unpinning is still accessed via systray.
- Streamlined the flow when the auth token expires; instead of showing an error, it just goes to the homepage again instead of showing a big `:(` with error message which is kinda scary when opening it up while live on stream.
- Added some dev-only buttons for resetting-FTUE/expiring-auth/restoring-auth to help testing the above features.

Disclosure: I largely used Github Copilot to write the code changes, but I manually tested and made many minor adjustments by hand afterwards.

<img width="601" height="437" alt="image" src="https://github.com/user-attachments/assets/e464237a-a5b9-467c-b30b-c2715a43c131" />

<img width="425" height="465" alt="image" src="https://github.com/user-attachments/assets/afffd1ce-0f2b-4aed-aa72-c31e35f8a732" />

