### PR TITLE
Keep the NavBar while pinned

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -38,14 +38,12 @@ function App() {
         pin ? null : "border border-zinc-600"
       )}
     >
-      {!pin && (
-        <NavBar
-          isUpdateAvailable={update?.available ?? false}
-          pin={pin}
-          alignDirection={horizontal}
-          setAlignDirection={setHorizontalDirection}
-        />
-      )}
+      <NavBar
+        isUpdateAvailable={update?.available ?? false}
+        pin={pin}
+        alignDirection={horizontal}
+        setAlignDirection={setHorizontalDirection}
+      />
       <Toaster />
       <Routes>
         <Route path="/" Component={MainView} />


### PR DESCRIPTION
The NavBar already gets hidden while pinned, no need to remove it from the DOM. Keeping it ensures the MainView stays in the same position (and does not move up a bit when pinned) making it a more consistent experience for the user.