### PR TITLE
Fix config dir opening on linux

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ tauri-plugin-os = "2.2.0"
 tauri-plugin-http = "2.2.0"
 tauri-plugin-log = "2.2.0"
 tauri-plugin-notification = "2.2.0"
+tauri-plugin-opener = "2.2.0"
 anyhow = "1.0.86"
 log = "0.4.22"
 

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -240,6 +240,8 @@ pub fn open_config_dir(app: tauri::AppHandle) {
   use tauri_plugin_opener::OpenerExt;
   if let Ok(path) = app.path().app_config_dir() {
     let _ = std::fs::create_dir_all(&path);
-    let _ = app.opener().open_path(path.to_string_lossy().to_string(), None::<&str>);
+    let _ = app
+      .opener()
+      .open_path(path.to_string_lossy().to_string(), None::<&str>);
   }
 }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -233,3 +233,13 @@ pub fn set_hide_taskbar_when_pinned(
     hide_taskbar_when_pinned,
   );
 }
+
+#[tauri::command]
+pub fn open_config_dir(app: tauri::AppHandle) {
+  use tauri::Manager;
+  use tauri_plugin_opener::OpenerExt;
+  if let Ok(path) = app.path().app_config_dir() {
+    let _ = std::fs::create_dir_all(&path);
+    let _ = app.opener().open_path(path.to_string_lossy().to_string(), None::<&str>);
+  }
+}

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -101,6 +101,7 @@ fn main() {
     .plugin(tauri_plugin_shell::init())
     .plugin(tauri_plugin_os::init())
     .plugin(tauri_plugin_http::init())
+    .plugin(tauri_plugin_opener::init())
     .plugin(log_plugin_builder.build());
 
   #[cfg(not(debug_assertions))]
@@ -172,6 +173,7 @@ fn main() {
       close_settings,
       open_settings,
       set_hide_taskbar_when_pinned,
+      open_config_dir,
     ]);
 
   app

--- a/apps/desktop/src/views/settings/account.tsx
+++ b/apps/desktop/src/views/settings/account.tsx
@@ -22,10 +22,8 @@ import { usePin } from "@/hooks/use-pin";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Pin } from "lucide-react";
 import type { VoiceUser } from "@/types";
-import * as shell from "@tauri-apps/plugin-shell";
 
 export const Developer = () => {
-  const platformInfo = usePlatformInfo();
   const DEV_TOKEN_BACKUP_KEY = "overlayed:dev:token-backup";
   const DEV_TOKEN_EXPIRY_BACKUP_KEY = "overlayed:dev:token-expiry-backup";
   const DEV_USER_DATA_BACKUP_KEY = "overlayed:dev:user-data-backup";
@@ -91,7 +89,7 @@ export const Developer = () => {
             size="sm"
             variant="outline"
             onClick={async () => {
-              await shell.open(platformInfo.configDir);
+              await invoke("open_config_dir");
             }}
           >
             Open Config Dir


### PR DESCRIPTION
If the config file did not exist on linux, the "Open Config Dir" button did just silently fail