### PR TITLE
Hide taskbar: Add linux to target_os for set_skip_taskbar

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -123,7 +123,7 @@ fn apply_taskbar_visibility(app: &AppHandle, pinned: bool, hide_taskbar_when_pin
   let skip_taskbar = pinned && hide_taskbar_when_pinned;
 
   if let Some(main_window) = app.get_webview_window(MAIN_WINDOW_NAME) {
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     main_window.set_skip_taskbar(skip_taskbar).ok();
   }
 


### PR DESCRIPTION
* Follow-up to 'Option to hide taskbar when pinned' as under X11 compositor (linux) with the cinnamon DE, the taskbar does not hide unless using set_skip_taskbar.

** Not sure about the state of tauri with wayland support for this feature but there was an older discussion [here](https://github.com/tauri-apps/tauri/issues/9829) for reference for follow-up.

<!-- gk-ai-analysis-start:599a5e14f4712ff14aa16541d239a25bb6d2b977 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiRW5hYmxlcyBoaWRpbmcgdGhlIGFwcGxpY2F0aW9uIGZyb20gdGhlIHRhc2tiYXIgb24gTGludXggYnkgZXhwYW5kaW5nIHRoZSB0YXJnZXRfb3MgY29uZmlndXJhdGlvbi4iLCJrZXlJbnNpZ2h0cyI6W3sidGl0bGUiOiJFbmFibGUgc2tpcCB0YXNrYmFyIG9uIExpbnV4IiwiZGVzY3JpcHRpb24iOiJUaGUgY29uZmlndXJhdGlvbiBhdHRyaWJ1dGUgZm9yIGNhbGxpbmcgYHNldF9za2lwX3Rhc2tiYXJgIGhhcyBiZWVuIHVwZGF0ZWQgdG8gaW5jbHVkZSBgdGFyZ2V0X29zID0gXCJsaW51eFwiYCwgYWxsb3dpbmcgdGhlIGFwcGxpY2F0aW9uIHRvIGJlIGhpZGRlbiBmcm9tIHRoZSB0YXNrYmFyIG9uIExpbnV4IGRlc2t0b3AgZW52aXJvbm1lbnRzLiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJhcHBzL2Rlc2t0b3Avc3JjLXRhdXJpL3NyYy9jb21tYW5kcy5ycyIsImxpbmVTdGFydCI6MTI2fV0sImlzc3VlcyI6W10sInN1Z2dlc3Rpb25zIjpbXSwic2VjdXJpdHkiOltdfQ== -->
<!-- gk-ai-analysis-end:599a5e14f4712ff14aa16541d239a25bb6d2b977 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/overlayeddev/overlayed/pull/287?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->