### PR TITLE
settings: fix unreadable dropdowns (Linux)

### DIFF
--- a/apps/desktop/src/views/settings/configuration.tsx
+++ b/apps/desktop/src/views/settings/configuration.tsx
@@ -77,7 +77,13 @@ export const Configuration = () => {
 
             await emit("config_update", await Config.getConfig());
           }}
-          className="w-40 p-1 rounded border bg-zinc-800 text-white outline-none focus:ring-0 cursor-pointer"
+          className="w-40 p-1 pr-8 rounded border bg-zinc-800 text-white outline-none focus:ring-0 cursor-pointer appearance-none bg-no-repeat"
+          style={{
+            backgroundImage:
+              "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E\")",
+            backgroundPosition: "right 0.5rem center",
+            backgroundSize: "12px",
+          }}
         >
           <option value="left" className="bg-zinc-800 text-white">
             Left
@@ -106,7 +112,13 @@ export const Configuration = () => {
 
             await emit("config_update", await Config.getConfig());
           }}
-          className="w-40 p-1 rounded border bg-zinc-800 text-white outline-none focus:ring-0 cursor-pointer"
+          className="w-40 p-1 pr-8 rounded border bg-zinc-800 text-white outline-none focus:ring-0 cursor-pointer appearance-none bg-no-repeat"
+          style={{
+            backgroundImage:
+              "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E\")",
+            backgroundPosition: "right 0.5rem center",
+            backgroundSize: "12px",
+          }}
         >
           <option value="top" className="bg-zinc-800 text-white">
             Top
@@ -132,7 +144,13 @@ export const Configuration = () => {
 
             await emit("config_update", await Config.getConfig());
           }}
-          className="p-1 rounded border bg-zinc-800 text-white outline-none focus:ring-0 cursor-pointer"
+          className="p-1 pr-8 rounded border bg-zinc-800 text-white outline-none focus:ring-0 cursor-pointer appearance-none bg-no-repeat"
+          style={{
+            backgroundImage:
+              "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E\")",
+            backgroundPosition: "right 0.5rem center",
+            backgroundSize: "12px",
+          }}
         >
           <option value="all" className="bg-zinc-800 text-white">
             Everything


### PR DESCRIPTION
Before:
<img width="599" height="517" alt="Screenshot from 2026-08-19 07-41-12" src="https://github.com/user-attachments/assets/2a87525d-8f4c-4015-a86a-51526653f70b" />
After: 
<img width="602" height="523" alt="Screenshot from 2026-08-19 07-56-12" src="https://github.com/user-attachments/assets/eb874de4-7675-4efd-b72b-737c4780f45d" />

